### PR TITLE
Print each datatype's schema

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,8 @@
 linters-settings:
   cyclop:
-    max-complexity: 13
+    max-complexity: 15
   gocyclo:
-    min-complexity: 13
+    min-complexity: 15
   gofumpt:
     lang-version: 1.18
   lll:

--- a/cmd/jostler/main.go
+++ b/cmd/jostler/main.go
@@ -1,4 +1,8 @@
 // Package main implements jostler.
+//
+// We use log.Panicf() instead of log.Fatalf() because log.Fatalf()
+// calls os.Exit() which will not run deferred calls and also makes
+// testing harder (for testing, we can recover from log.Panicf()).
 package main
 
 import (
@@ -19,27 +23,27 @@ import (
 	"github.com/m-lab/go/host"
 	"github.com/rjeczalik/notify"
 
-	"github.com/m-lab/jostler/uploadbundle"
-	"github.com/m-lab/jostler/watchdir"
+	"github.com/m-lab/jostler/internal/uploadbundle"
+	"github.com/m-lab/jostler/internal/watchdir"
 )
 
 var (
 	// Flags related to GCS.
-	bucket       = flag.String("gcs-bucket", "", "required: GCS bucket name")
+	bucket       = flag.String("gcs-bucket", "", "GCS bucket name")
 	gcsHomeDir   = flag.String("gcs-home-dir", "autoload/v0", "home directory in GCS bucket under which bundles will be uploaded")
-	mlabNodeName = flag.String("mlab-node-name", "", "required: node name specified directly or via MLAB_NODE_NAME env variable")
+	mlabNodeName = flag.String("mlab-node-name", "", "node name specified directly or via MLAB_NODE_NAME env variable")
 
 	// Flags related to bundles.
 	goldenRows    = flagx.StringArray{}
-	bundleSizeMax = flag.Uint("bundle-size-max", 20*1024*1024, "maximum size in bytes of a bundle before it is uploaded")
-	bundleAgeMax  = flag.Duration("bundle-age-max", 1*time.Hour, "maximum age of a bundle before it is uploaded")
+	bundleSizeMax = flag.Uint("bundle-size-max", 20*1024*1024, "maximum bundle size in bytes before it is uploaded")
+	bundleAgeMax  = flag.Duration("bundle-age-max", 1*time.Hour, "maximum bundle age before it is uploaded")
 	bundleNoRm    = flag.Bool("no-rm", false, "do not remove files of a bundle after successful upload") // XXX debugging support - delete when done
 
 	// Flags related to where to watch for data (inotify events).
-	dataHomeDir    = flag.String("data-home-dir", "/cache/data", "directory pathname under which experiment data is created")
+	dataHomeDir    = flag.String("data-home-dir", "/var/spool", "directory pathname under which experiment data is created")
 	extensions     = flagx.StringArray{".json"}
-	experiment     = flag.String("experiment", "", "required: name of the experiment (e.g., ndt)")
-	datatypes      = flagx.StringArray{} // required
+	experiment     = flag.String("experiment", "", "name of the experiment (e.g., ndt)")
+	datatypes      = flagx.StringArray{}
 	missedAge      = flag.Duration("missed-age", 3*time.Hour, "minimum duration since a file's last modification time before it is considered missed")
 	missedInterval = flag.Duration("missed-interval", 30*time.Minute, "time interval between scans of filesystem for missed files")
 
@@ -52,34 +56,41 @@ var (
 	errNoBucket      = errors.New("must specify GCS bucket")
 	errNoExperiment  = errors.New("must specify experiment")
 	errNoDatatype    = errors.New("must specify at least one datatype")
-	errMismatch      = errors.New("mismatch between the number of golden row(s) and datatype(s)")
+	errMismatch      = errors.New("mismatch between golden row(s) and datatype(s)")
 	errGRowArgFormat = errors.New("is not in <datatype>:<pathname> format")
-	errNoGRowFile    = errors.New("failed to find golden row")
 	errInvalidGRow   = errors.New("failed to validate golden row")
 	errStatFile      = errors.New("failed to stat file")
 	errReadFile      = errors.New("failed to read file")
+	errMarshal       = errors.New("failed to marshal")
 )
 
 func init() {
 	flag.Var(&goldenRows, "golden-row", "golden row for each datatype in the format <datatype>:<pathname>")
 	flag.Var(&extensions, "extensions", "filename extensions to watch within <data-dir>/<experiment>")
-	flag.Var(&datatypes, "datatype", "required: datatype(s) to watch within <data-dir>/<experiment>")
+	flag.Var(&datatypes, "datatype", "datatype(s) to watch within <data-dir>/<experiment>")
 }
 
+// main supports two modes of operation:
+//   - A short-lived interactive mode, enabled by the -schema flag,
+//     to create and upload schema files to GCS.
+//   - A long-lived non-interactive mode to bundle and upload data to GCS.
 func main() {
 	log.SetFlags(log.Ltime)
 	if err := parseAndValidateCLI(); err != nil {
-		log.Panicf("invalid command line: %v", err)
+		log.Panic(err)
 	}
+	// In verbose mode, enable verbose logging (mostly for debugging).
 	if *verbose {
 		watchdir.Verbose(vLogf)
 		uploadbundle.Verbose(vLogf)
 	}
 
 	if *schema {
-		createSchemas()
+		if err := createSchemas(); err != nil {
+			log.Panic(err)
+		}
 	} else {
-		uploadBundles()
+		watchAndUpload()
 	}
 }
 
@@ -108,9 +119,9 @@ func parseAndValidateCLI() error {
 		if *bucket == "" {
 			return errNoBucket
 		}
-	}
-	if *experiment == "" {
-		return errNoExperiment
+		if *experiment == "" {
+			return errNoExperiment
+		}
 	}
 	if len(datatypes) == 0 {
 		return errNoDatatype
@@ -118,79 +129,71 @@ func parseAndValidateCLI() error {
 	if len(goldenRows) > len(datatypes) {
 		return errMismatch
 	}
+	// Validate that for each golden row file, its corresponding
+	// datatype has been specified.
+	for _, gRow := range goldenRows {
+		idx := strings.Index(gRow, ":")
+		if idx == -1 {
+			return fmt.Errorf("%v: %w", gRow, errGRowArgFormat)
+		}
+		found := false
+		for _, datatype := range datatypes {
+			if datatype == gRow[:idx] {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("%v: %w", gRow, errMismatch)
+		}
+	}
 	return nil
 }
 
 // createSchemas creates schema files for each datatype.  These schema files
 // will be used to create BigQuery tables.
-func createSchemas() {
+func createSchemas() error {
 	for _, datatype := range datatypes {
-		_, err := goldenRowForDatatype(datatype)
+		gRow, err := goldenRowForDatatype(datatype)
 		if err != nil {
-			log.Panicf("invalid golden row: %v", err)
+			return err
 		}
-	}
-}
-
-// uploadBundles uploads JSONL bundles from M-Lab nodes to GCS.  These JSONL
-// bundles will be loaded to BigQuery.
-func uploadBundles() {
-	// Parse the M-Lab hostname (which should be one of the following
-	// formats) into its constituent parts.
-	// v1: <machine>.<site>.measuremen-lab.org
-	// v2: <machine>.<site>.<project>.measurement-lab.org
-	nameParts, err := host.Parse(*mlabNodeName)
-	if err != nil {
-		log.Panic(err)
-	}
-
-	// For each datatype, start a directory watcher and a bundle
-	// uploader.
-	watchEvents := []notify.Event{notify.InCloseWrite, notify.InMovedTo}
-	wg := sync.WaitGroup{}
-	for _, datatype := range datatypes {
-		wdClient, err := startWatcher(&wg, datatype, watchEvents)
+		schema := uploadbundle.StandardColumns{
+			Date: "yyyy/mm/dd",
+			Archiver: uploadbundle.Archiver{
+				Version:    "jostler@v0.0.0",
+				GitCommit:  "3ac4528",
+				ArchiveURL: "gs://bucket-name/object-name",
+				Filename:   "/full/pathname",
+			},
+			Raw: gRow,
+		}
+		schemaBytes, err := json.Marshal(schema)
 		if err != nil {
-			log.Panicf("failed to start directory watcher: %v", err)
+			return fmt.Errorf("%v: %w", errMarshal, err)
 		}
-		goldenRow, err := goldenRowForDatatype(datatype)
-		if err != nil {
-			log.Panicf("invalid golden row: %v", err)
-		}
-		if err := startBundleUploader(&wg, datatype, goldenRow, nameParts, wdClient); err != nil {
-			log.Panicf("failed to start bundle uploader: %v", err)
-		}
+		fmt.Printf("%s\n", string(schemaBytes)) //nolint
 	}
-	// If there's an unrecoverable error that causes channels
-	// to close or if the main context is explicitly canceled, the
-	// goroutines created in startWatcher() and startBundleUploader()
-	// will terminate and the following Wait() returns.
-	wg.Wait()
+	return nil
 }
 
 // goldenRowForDatatype validates the golden row file for the given datatype.
-// By default are in /var/spool/<experiment>/<datatype>/golden-row.json
-// but can also be specified via the --golden-row flag.  For example,
+// By default golden rows are in /var/spool/datatypes/<datatype>/golden-row.json
+// but can also be specified via the -golden-row flag.  For example,
 // for datatype foo1, it can be: foo1:<path>/<to>/<foo1-golden-row.json>.
 func goldenRowForDatatype(datatype string) (string, error) {
 	gRowFile := ""
 	for _, gRow := range goldenRows {
-		if !strings.Contains(gRow, ":") {
-			return "", fmt.Errorf("%v: %w", gRow, errGRowArgFormat)
-		}
 		if strings.HasPrefix(gRow, datatype+":") {
 			gRowFile = gRow[len(datatype)+1:]
 			break
 		}
 	}
 	if gRowFile == "" {
-		gRowFile = filepath.Join("/var/spool", *experiment, datatype, "golden-row.json")
+		gRowFile = filepath.Join("/var/spool/datatypes", datatype, "golden-row.json")
 	}
 	vLogf("checking golden row file %v for datatype %v", gRowFile, datatype)
 	if _, err := os.Stat(gRowFile); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return "", fmt.Errorf("%v: %w", datatype, errNoGRowFile)
-		}
 		return "", fmt.Errorf("%v: %w", errStatFile, err)
 	}
 
@@ -205,10 +208,40 @@ func goldenRowForDatatype(datatype string) (string, error) {
 	return strings.TrimSuffix(string(gRowBytes), "\n"), nil
 }
 
+// watchAndUpload bundles individual JSON files into JSONL bundles and
+// uploads the bundles to GCS.
+func watchAndUpload() {
+	// For each datatype, start a directory watcher and a bundle
+	// uploader.
+	watchEvents := []notify.Event{notify.InCloseWrite, notify.InMovedTo}
+	wg := sync.WaitGroup{}
+	mainCtx, mainCancel := context.WithCancel(context.Background())
+	defer mainCancel()
+	for _, datatype := range datatypes {
+		wdClient, err := startWatcher(mainCtx, mainCancel, &wg, datatype, watchEvents)
+		if err != nil {
+			log.Panicf("failed to start directory watcher: %v", err)
+		}
+		goldenRow, err := goldenRowForDatatype(datatype)
+		if err != nil {
+			log.Panic(err)
+		}
+		if err := startUploader(mainCtx, mainCancel, &wg, datatype, goldenRow, wdClient); err != nil {
+			log.Panicf("failed to start bundle uploader: %v", err)
+		}
+	}
+
+	// If there's an unrecoverable error that causes channels
+	// to close or if the main context is explicitly canceled, the
+	// goroutines created in startWatcher() and startBundleUploader()
+	// will terminate and the following Wait() returns.
+	wg.Wait()
+}
+
 // startWatcher starts a directory watcher goroutine that watches the
 // specified directory and notifies its client of new (and potentially
 // missed) files.
-func startWatcher(wg *sync.WaitGroup, datatype string, watchEvents []notify.Event) (*watchdir.WatchDir, error) {
+func startWatcher(mainCtx context.Context, mainCancel context.CancelFunc, wg *sync.WaitGroup, datatype string, watchEvents []notify.Event) (*watchdir.WatchDir, error) {
 	watchDir := filepath.Join(*dataHomeDir, *experiment, datatype)
 	wdClient, err := watchdir.New(watchDir, extensions, watchEvents, *missedAge, *missedInterval)
 	if err != nil {
@@ -217,43 +250,51 @@ func startWatcher(wg *sync.WaitGroup, datatype string, watchEvents []notify.Even
 
 	wg.Add(1)
 	go func(wdClient *watchdir.WatchDir) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		wdClient.WatchAndNotify(ctx)
-		vLogf("WatchAndNotify() returned")
+		defer mainCancel()
+		wdClient.WatchAndNotify(mainCtx)
 		wg.Done()
 	}(wdClient)
 	return wdClient, nil
 }
 
-// startBundleUploader starts a bundle uploader goroutine that bundles
-// individual JSON files into JSONL bundles and uploads them to GCS.
-func startBundleUploader(wg *sync.WaitGroup, datatype, goldenRow string, nameParts host.Name, wdClient *watchdir.WatchDir) error {
+// startUploader start a bundle uploader goroutine that bundles
+// individual JSON files into JSONL bundle and uploads it to GCS.
+func startUploader(mainCtx context.Context, mainCancel context.CancelFunc, wg *sync.WaitGroup, datatype, goldenRow string, wdClient *watchdir.WatchDir) error {
+	// Parse the M-Lab hostname (which should be in one of the
+	// following formats) into its constituent parts.
+	// v1: <machine>.<site>.measuremen-lab.org
+	// v2: <machine>.<site>.<project>.measurement-lab.org
+	nameParts, err := host.Parse(*mlabNodeName)
+	if err != nil {
+		log.Panic(err)
+	}
+
 	gcsConf := uploadbundle.GCSConfig{
 		Bucket:  *bucket,
 		DataDir: filepath.Join(*gcsHomeDir, *experiment, datatype),
 		BaseID:  fmt.Sprintf("%s-%s-%s-%s", datatype, nameParts.Machine, nameParts.Site, *experiment),
 	}
 	bundleConf := uploadbundle.BundleConfig{
+		Datatype:  datatype,
 		DataDir:   filepath.Join(*dataHomeDir, *experiment, datatype),
 		GoldenRow: goldenRow,
 		SizeMax:   *bundleSizeMax,
 		AgeMax:    *bundleAgeMax,
 		NoRm:      *bundleNoRm,
 	}
-	ub, err := uploadbundle.New(wdClient, gcsConf, bundleConf)
+	ubClient, err := uploadbundle.New(wdClient, gcsConf, bundleConf)
 	if err != nil {
 		return fmt.Errorf("failed to instantiate uploader: %w", err)
 	}
 
 	wg.Add(1)
-	go func() {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		ub.BundleAndUpload(ctx)
-		vLogf("BundleAndUpload() returned")
+	go func(ubClient *uploadbundle.UploadBundle) {
+		defer mainCancel()
+		// BundleAndUpload() runs forever unless somehow the
+		// context is canceled or the channels it uses are closed.
+		ubClient.BundleAndUpload(mainCtx)
 		wg.Done()
-	}()
+	}(ubClient)
 	return nil
 }
 

--- a/internal/watchdir/watchdir.go
+++ b/internal/watchdir/watchdir.go
@@ -94,4 +94,12 @@ func New(watchDir string, watchExtensions []string, watchEvents []notify.Event, 
 // for the configured events and sends the pathnames of the events it received
 // through the configured channel.
 func (wd *WatchDir) WatchAndNotify(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			// We are all done.
+			verbose("context canceled; returning")
+			return
+		}
+	}
 }


### PR DESCRIPTION
This commit adds logic to generate the schema file for each datatype.  Currently it prints the result to the standard output. In a future commit, it will upload the schema file to GCS.

This commit also organizes source code by adding cmd and internal directories.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/jostler/2)
<!-- Reviewable:end -->
