### PR TITLE
Make source code consistent with design doc

### DIFF
--- a/cmd/jostler/cli.go
+++ b/cmd/jostler/cli.go
@@ -69,7 +69,7 @@ func initFlags() {
 	flag.BoolVar(&bundleNoRm, "no-rm", false, "do not remove files of a bundle after successful upload") // XXX debugging support - delete when done
 
 	// Flags related to where to watch for data (inotify events).
-	flag.StringVar(&dataHomeDir, "data-home-dir", "/var/spool", "directory pathname under which experiment data is created")
+	flag.StringVar(&dataHomeDir, "data-home-dir", "/var/spool", "directory pathname under which measurement data is created")
 	extensions = flagx.StringArray{".json"}
 	flag.StringVar(&experiment, "experiment", "", "required - name of the experiment (e.g., ndt)")
 	datatypes = flagx.StringArray{}

--- a/cmd/jostler/main.go
+++ b/cmd/jostler/main.go
@@ -30,11 +30,13 @@
 //  4. Fails to run.
 //
 // In summary, by default:
-//  1. Datatype schema files will be read from the local filesystem at:
+//  1. Measurement data files will be read from the local filesystem at:
+//     /var/spool/<experiment>/<datatype>/<yyyy>/<mm>/<dd>
+//  2. Datatype schema files will be read from the local filesystem at:
 //     /var/spool/datatypes/<datatype>.json
-//  2. Table schema files will be uploaded to GCS as:
+//  3. Table schema files will be uploaded to GCS as:
 //     autoload/v0/tables/<experiment>/<datatype>.table.json
-//  3. JSONL files will be uploaded to GCS as:
+//  4. JSONL files will be uploaded to GCS as:
 //     autoload/v0/<experiment>/<datatype>/<yyyy>/<mm>/<dd>/<timestamp>-<datatype>-<node-name>-<experiment>.jsonl.gz
 package main
 

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -27,8 +27,8 @@ type (
 )
 
 var (
-	datatypePathTemplate = "/var/spool/datatypes/{{DATATYPE}}.json"
-	objectPrefixTemplate = "autoload/v0/tables/{{EXPERIMENT}}/{{DATATYPE}}.table.json"
+	dtSchemaPathTemplate  = "/var/spool/datatypes/<datatype>.json"
+	tblSchemaPathTemplate = "autoload/v0/tables/<experiment>/<datatype>.table.json"
 
 	ErrReadSchema     = errors.New("failed to read schema file")
 	ErrSchemaFromJSON = errors.New("failed to create schema from JSON")
@@ -61,7 +61,7 @@ func PathForDatatype(datatype string, dtSchemaFiles []string) string {
 			return (dtSchemaFiles[i])[len(datatype)+1:]
 		}
 	}
-	return strings.Replace(datatypePathTemplate, "{{DATATYPE}}", datatype, 1)
+	return strings.Replace(dtSchemaPathTemplate, "<datatype>", datatype, 1)
 }
 
 // ValidateAndUpload compares the current table schema against the
@@ -103,8 +103,8 @@ func uploadTableSchema(bucket, experiment, datatype, dtSchemaFile string) error 
 	if err != nil {
 		return err
 	}
-	objPath := strings.Replace(objectPrefixTemplate, "{{EXPERIMENT}}", experiment, 1)
-	objPath = strings.Replace(objPath, "{{DATATYPE}}", datatype, 1)
+	objPath := strings.Replace(tblSchemaPathTemplate, "<experiment>", experiment, 1)
+	objPath = strings.Replace(objPath, "<datatype>", datatype, 1)
 	verbose("uploading '%v:%v'", bucket, objPath)
 	if err := GCSUpload(ctx, bucket, objPath, tblSchemaJSON); err != nil {
 		return fmt.Errorf("%v: %w", ErrUpload, err)
@@ -133,8 +133,8 @@ func checkTable(bucket, experiment, datatype, dtSchemaFile string) (*mapDiff, er
 	// there is nothing to validate for this datatype and the new table
 	// schema should be uploaded.
 	ctx := context.Background()
-	objPath := strings.Replace(objectPrefixTemplate, "{{EXPERIMENT}}", experiment, 1)
-	objPath = strings.Replace(objPath, "{{DATATYPE}}", datatype, 1)
+	objPath := strings.Replace(tblSchemaPathTemplate, "<experiment>", experiment, 1)
+	objPath = strings.Replace(objPath, "<datatype>", datatype, 1)
 	verbose("downloading '%v:%v'", bucket, objPath)
 	oldTblSchemaJSON, err := GCSDownload(ctx, bucket, objPath)
 	if err != nil {

--- a/internal/uploadbundle/uploadbundle.go
+++ b/internal/uploadbundle/uploadbundle.go
@@ -36,21 +36,22 @@ type UploadBundle struct {
 
 // GCSConfig defines GCS configuration options.
 //
-// BaseID is the ID component in the base name of
-// the JSONL bundles and can be any string.  M-Lab uses
-// "<datatype>-<machine>-<site>-<experiment>".  For example, the BaseID
-// of bundle "20220914T143133.179976Z-foo1-mlab3-akl01-ndt.jsonl.gz" is
-// "foo1-mlab3-akl01-ndt".
+// GCS object names of JSONL bundles have the following format:
+// autoload/v0/<experiment>/<datatype>/<yyyy>/<mm>/<dd>/<timestamp>-<datatype>-<node-name>-<experiment>.jsonl.gz
+// |------------DataDir--------------|                              |-------------BaseID--------------|
+//
+// Note that while slashes ("/") in GCS object names create the illusion
+// of a directory hierarchy, GCS has a flat namesapce.
 type GCSConfig struct {
 	Bucket  string // GCS bucket name
-	DataDir string // "path" to datatype subdirectory in GCS (e.g., /autoload/v0/tables/<experiment>/<datatype>.table.json)
-	BaseID  string // ID component in the filename of JSONL bundle (e.g., <datatype>-<machine>-<site>-<experiment>)
+	DataDir string // see the above comment
+	BaseID  string // see the above comment
 }
 
 // BundleConfig defines bundle configuration options.
 type BundleConfig struct {
 	Datatype string        // datatype (e.g., scamper1)
-	DataDir  string        // path to datatype subdirectory on local disk (e.g., /cache/data/<experiment>/<datatype>)
+	DataDir  string        // path to datatype subdirectory on local disk (e.g., /var/spool/<experiment>/<datatype>)
 	SizeMax  uint          // bundle will be uploaded when it reaches this size
 	AgeMax   time.Duration // bundle will be uploaded when it reaches this age
 	NoRm     bool          // XXX debugging support - delete when done


### PR DESCRIPTION
The purpose of this commit is to make default pathnames, variable names, and comments in the source code consistent with the autoloading design document.

There is no functionality change.

Tested the changes with golangci-lint and go test ./...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/jostler/9)
<!-- Reviewable:end -->
