### PR TITLE
Split uploadbundle into two packages

### DIFF
--- a/api/standard_columns.go
+++ b/api/standard_columns.go
@@ -2,6 +2,11 @@ package api
 
 // StandardColumnsV0 defines version 0 of the standard columns included
 // in every line (row) along with the raw data from the measurement service.
+//
+// Note that the Raw field is a placeholder for the actual measurement
+// data in JSON format produced by the measurement service.  Ideally, its
+// type should be declared as "any" but bigquery.InferSchema() does not
+// support "any" (or "interface{}").
 type StandardColumnsV0 struct {
 	Date     string     `bigquery:"date"`     // yyyy-mm-dd pathname component of measurement data
 	Archiver ArchiverV0 `bigquery:"archiver"` // archiver details

--- a/cmd/jostler/cli.go
+++ b/cmd/jostler/cli.go
@@ -27,7 +27,6 @@ var (
 	dtSchemaFiles flagx.StringArray
 	bundleSizeMax uint
 	bundleAgeMax  time.Duration
-	bundleNoRm    bool
 
 	// Flags related to where to watch for data (inotify events).
 	dataHomeDir    string
@@ -64,7 +63,6 @@ func initFlags() {
 	dtSchemaFiles = flagx.StringArray{}
 	flag.UintVar(&bundleSizeMax, "bundle-size-max", 20*1024*1024, "maximum bundle size in bytes before it is uploaded")
 	flag.DurationVar(&bundleAgeMax, "bundle-age-max", 1*time.Hour, "maximum bundle age before it is uploaded")
-	flag.BoolVar(&bundleNoRm, "no-rm", false, "do not remove files of a bundle after successful upload") // XXX debugging support - delete when done
 
 	// Flags related to where to watch for data (inotify events).
 	flag.StringVar(&dataHomeDir, "data-home-dir", "/var/spool", "directory pathname under which measurement data is created")

--- a/cmd/jostler/cli.go
+++ b/cmd/jostler/cli.go
@@ -37,6 +37,8 @@ var (
 	missedInterval time.Duration
 
 	// Flags related to program's execution.
+	version      string
+	gitCommit    string
 	local        bool
 	verbose      bool
 	testInterval time.Duration
@@ -73,6 +75,8 @@ func initFlags() {
 	flag.DurationVar(&missedInterval, "missed-interval", 30*time.Minute, "time interval between scans of filesystem for missed files")
 
 	// Flags related to program's execution.
+	flag.StringVar(&version, "versiondir", "", "version of this program, usually its release tag (e.g., v0.1.7)")
+	flag.StringVar(&gitCommit, "git-commit", "", "git commit SHA1 of this program, usually its HEAD commit SHA1")
 	flag.BoolVar(&local, "local", false, "run locally and create schema files for each datatype")
 	flag.BoolVar(&verbose, "verbose", false, "enable verbose mode")
 	flag.DurationVar(&testInterval, "test-interval", 0, "time interval to stop running (for test purposes only)")

--- a/cmd/jostler/cli.go
+++ b/cmd/jostler/cli.go
@@ -37,8 +37,6 @@ var (
 	missedInterval time.Duration
 
 	// Flags related to program's execution.
-	version      string
-	gitCommit    string
 	local        bool
 	verbose      bool
 	testInterval time.Duration
@@ -75,8 +73,6 @@ func initFlags() {
 	flag.DurationVar(&missedInterval, "missed-interval", 30*time.Minute, "time interval between scans of filesystem for missed files")
 
 	// Flags related to program's execution.
-	flag.StringVar(&version, "versiondir", "", "version of this program, usually its release tag (e.g., v0.1.7)")
-	flag.StringVar(&gitCommit, "git-commit", "", "git commit SHA1 of this program, usually its HEAD commit SHA1")
 	flag.BoolVar(&local, "local", false, "run locally and create schema files for each datatype")
 	flag.BoolVar(&verbose, "verbose", false, "enable verbose mode")
 	flag.DurationVar(&testInterval, "test-interval", 0, "time interval to stop running (for test purposes only)")

--- a/cmd/jostler/main.go
+++ b/cmd/jostler/main.go
@@ -149,13 +149,7 @@ func daemonMode() error {
 	var err error
 	select {
 	case err = <-watcherStatus:
-		if err != nil {
-			log.Printf("watcher failed: %v\n", err)
-		}
 	case err = <-uploaderStatus:
-		if err != nil {
-			log.Printf("uploader failed: %v\n", err)
-		}
 	}
 	mainCancel()
 	return err
@@ -196,9 +190,8 @@ func startUploader(mainCtx context.Context, mainCancel context.CancelFunc, statu
 		DataDir:  filepath.Join(dataHomeDir, experiment, datatype),
 		SizeMax:  bundleSizeMax,
 		AgeMax:   bundleAgeMax,
-		NoRm:     bundleNoRm,
 	}
-	ubClient, err := uploadbundle.New(wdClient, gcsConf, bundleConf)
+	ubClient, err := uploadbundle.New(mainCtx, wdClient, gcsConf, bundleConf)
 	if err != nil {
 		return nil, fmt.Errorf("failed to instantiate uploader: %w", err)
 	}

--- a/cmd/jostler/main.go
+++ b/cmd/jostler/main.go
@@ -58,6 +58,9 @@ import (
 )
 
 var (
+	version   string // set at build time from git describe --tags
+	gitCommit string // set at build time from git log -1 --format=%h
+
 	errWrite = errors.New("failed to write file")
 
 	// Test code changes Fatal to Panic so a fatal error won't exit

--- a/cmd/jostler/main.go
+++ b/cmd/jostler/main.go
@@ -186,10 +186,12 @@ func startUploader(mainCtx context.Context, mainCancel context.CancelFunc, statu
 		BaseID:  fmt.Sprintf("%s-%s-%s-%s", datatype, nameParts.Machine, nameParts.Site, experiment),
 	}
 	bundleConf := uploadbundle.BundleConfig{
-		Datatype: datatype,
-		DataDir:  filepath.Join(dataHomeDir, experiment, datatype),
-		SizeMax:  bundleSizeMax,
-		AgeMax:   bundleAgeMax,
+		Version:   version,
+		GitCommit: gitCommit,
+		Datatype:  datatype,
+		DataDir:   filepath.Join(dataHomeDir, experiment, datatype),
+		SizeMax:   bundleSizeMax,
+		AgeMax:    bundleAgeMax,
 	}
 	ubClient, err := uploadbundle.New(mainCtx, wdClient, gcsConf, bundleConf)
 	if err != nil {

--- a/cmd/jostler/main_test.go
+++ b/cmd/jostler/main_test.go
@@ -16,7 +16,7 @@ import (
 const (
 	testNode        = "mlab1-lga01.mlab-sandbox.measurement-lab.org"
 	testDataHomeDir = "testdata"    // typically /var/spool
-	testBucket      = "fake-bucket" // typically pusher-mlab-sandbox
+	testBucket      = "disk-bucket" // typically pusher-mlab-sandbox
 	testExperiment  = "jostler"
 	testDatatype    = "foo1"
 )
@@ -176,10 +176,10 @@ func TestCLI(t *testing.T) { //nolint:funlen,paralleltest
 			},
 		},
 	}
-	// Use a fake GCS implementation that reads from and writes to
-	// the local filesystemi.
+	// Use a local disk storage implementation that mimics downloads
+	// from and uploads to GCS.
 	saveGCSClient := schema.GCSClient
-	schema.GCSClient = testhelper.FakeNewClient
+	schema.GCSClient = testhelper.DiskClient
 	defer func() {
 		schema.GCSClient = saveGCSClient
 		os.RemoveAll("foo1.json")

--- a/internal/jsonlbundle/jsonlbundle.go
+++ b/internal/jsonlbundle/jsonlbundle.go
@@ -79,7 +79,8 @@ func (jb *JSONLBundle) HasFile(fullPath string) bool {
 	return false
 }
 
-// AddFile adds the specified file to the bundle.
+// AddFile adds the specified measurement data file in JSON format to
+// the bundle by embedding it in the Raw field of M-Lab's standard columns.
 func (jb *JSONLBundle) AddFile(fullPath, version, gitCommit string) error {
 	contents, err := readJSONFile(fullPath)
 	if err != nil {
@@ -94,12 +95,13 @@ func (jb *JSONLBundle) AddFile(fullPath, version, gitCommit string) error {
 			ArchiveURL: fmt.Sprintf("gs://%s/%s/%s", jb.bucket, jb.ObjDir, jb.ObjName),
 			Filename:   fullPath,
 		},
-		Raw: "",
+		Raw: "", // placeholder for measurement data
 	}
 	stdColsBytes, err := json.Marshal(stdCols)
 	if err != nil {
 		log.Panicf("failed to marshal standard columns: %v", err)
 	}
+	// Replace the placeholder Raw with the actual measurement data.
 	line := strings.Replace(string(stdColsBytes), `"Raw":""`, `"Raw":`+contents, 1)
 	jb.Lines = append(jb.Lines, line)
 	jb.FullPaths = append(jb.FullPaths, fullPath)

--- a/internal/jsonlbundle/jsonlbundle.go
+++ b/internal/jsonlbundle/jsonlbundle.go
@@ -1,0 +1,140 @@
+// Package jsonbundle implements logic to process a single JSONL bundle.
+package jsonlbundle
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/m-lab/jostler/api"
+)
+
+// JSONLBundle defines a collection of JSON file contents bundled together
+// in JSONL format for archiving.
+type JSONLBundle struct {
+	Lines      []string
+	Timestamp  string   // bundle's in-memory creation time that serves as its identifier
+	Datatype   string   // bundle's datatype
+	DateSubdir string   // date subdirectory of files in this bundle (yyyy/mm/dd)
+	bucket     string   // GCS bucket
+	ObjDir     string   // GCS directory to upload this bundle to
+	ObjName    string   // GCS object name of this bundle
+	IdxName    string   // name of the index file for this bundle
+	FullPaths  []string // pathnames of individual JSON files
+	BadFiles   []string // pathnames of files that could not be read or were not proper JSON
+	Size       uint     // size of this bundle
+}
+
+var (
+	ErrEmptyFile   = errors.New("empty file")
+	ErrInvalidJSON = errors.New("failed to validate JSON")
+	ErrNotOneLine  = errors.New("is not one line")
+
+	// Testing and debugging support.
+	verbose = func(fmt string, args ...interface{}) {}
+)
+
+// Verbose provides a convenient way for the caller to enable verbose
+// printing and control its format (mostly for debugging).
+func Verbose(v func(string, ...interface{})) {
+	verbose = v
+}
+
+// New returns a new instance of JSONLBundle.
+func New(bucket, gcsDataDir, gcsBaseID, datatype, dateSubdir string) *JSONLBundle {
+	nowUTC := time.Now().UTC()
+	objName := fmt.Sprintf("%s-%s", nowUTC.Format("20060102T150405.000000Z"), gcsBaseID)
+	return &JSONLBundle{
+		Lines:      []string{},
+		Timestamp:  time.Now().UTC().Format("2006/01/02T150405.000000Z"),
+		Datatype:   datatype,
+		DateSubdir: dateSubdir,
+		bucket:     bucket,
+		ObjDir:     fmt.Sprintf("%s/%s", gcsDataDir, nowUTC.Format("2006/01/02")), // e.g., ndt/pcap/2022/09/14
+		ObjName:    objName + ".jsonl",
+		IdxName:    objName + ".index",
+		FullPaths:  []string{},
+		BadFiles:   []string{},
+		Size:       0,
+	}
+}
+
+// Description returns a string describing the bundle for log messages.
+func (jb *JSONLBundle) Description() string {
+	return fmt.Sprintf("bundle <%v %v %v>", jb.Timestamp, jb.Datatype, jb.DateSubdir)
+}
+
+// HasFile returns true or false depending on whether the bundle includes
+// the given file or not.
+func (jb *JSONLBundle) HasFile(fullPath string) bool {
+	for _, p := range append(jb.FullPaths, jb.BadFiles...) {
+		if p == fullPath {
+			return true
+		}
+	}
+	return false
+}
+
+// AddFile adds the specified file to the bundle.
+func (jb *JSONLBundle) AddFile(fullPath string) error {
+	contents, err := readJSONFile(fullPath)
+	if err != nil {
+		jb.BadFiles = append(jb.BadFiles, fullPath)
+		return err
+	}
+	stdCols := api.StandardColumnsV0{
+		Date: jb.DateSubdir,
+		Archiver: api.ArchiverV0{
+			Version:    "jostler@0.1.7",
+			GitCommit:  "3ac4528",
+			ArchiveURL: fmt.Sprintf("gs://%s/%s/%s", jb.bucket, jb.ObjDir, jb.ObjName),
+			Filename:   fullPath,
+		},
+		Raw: "",
+	}
+	stdColsBytes, err := json.Marshal(stdCols)
+	if err != nil {
+		log.Panicf("failed to marshal standard columns: %v", err)
+	}
+	line := fmt.Sprintf("%s,\"raw\":%s}", strings.TrimSuffix(string(stdColsBytes), "}"), contents)
+	jb.Lines = append(jb.Lines, line)
+	jb.FullPaths = append(jb.FullPaths, fullPath)
+	jb.Size += uint(len(contents))
+	verbose("added %v to %v", fullPath, jb.Description())
+	return nil
+}
+
+// RemoveLocalFiles removes files on the local filesystem that were
+// successfully uploaded via this bundle.
+func (jb *JSONLBundle) RemoveLocalFiles() {
+	for _, fullPath := range append(jb.FullPaths, jb.BadFiles...) {
+		verbose("removing %v", fullPath)
+		if err := os.Remove(fullPath); err != nil {
+			log.Printf("ERROR: failed to remove: %v\n", err)
+		}
+	}
+}
+
+// readJSONFile reads the specified file and returns its contents if it
+// is valid JSON.
+func readJSONFile(fullPath string) (string, error) {
+	bytes, err := os.ReadFile(fullPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file: %w", err)
+	}
+	if len(bytes) == 0 {
+		return "", fmt.Errorf("%v: %w", fullPath, ErrEmptyFile)
+	}
+	if !json.Valid(bytes) {
+		return "", fmt.Errorf("%v: %w", fullPath, ErrInvalidJSON)
+	}
+	contents := strings.TrimSuffix(string(bytes), "\n")
+	if strings.Count(contents, "\n") != 0 {
+		return "", fmt.Errorf("%v: %w", fullPath, ErrNotOneLine)
+	}
+	return contents, nil
+}

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -21,8 +21,9 @@ func TestVerbose(t *testing.T) { //nolint:paralleltest
 }
 
 func TestPathForDatatype(t *testing.T) { //nolint:paralleltest
-	// Since PathForDatatype() should not download from or upload
-	// to GCS, set bucket to "" to force a panic in fake GCS.
+	// Since PathForDatatype() should not download from or upload to
+	// GCS, set bucket to "" to force a panic in the local disk storage
+	// implementation.
 	tests := []struct {
 		bucket        string
 		datatype      string
@@ -30,13 +31,13 @@ func TestPathForDatatype(t *testing.T) { //nolint:paralleltest
 		want          string
 	}{
 		{
-			bucket:        "fake-bucket",
+			bucket:        "disk-bucket",
 			datatype:      testDatatype,
 			dtSchemaFiles: []string{"foo1:/path/to/foo1.json", "bar1:/path/to/bar1.json"},
 			want:          "/path/to/foo1.json",
 		},
 		{
-			bucket:        "fake-bucket",
+			bucket:        "disk-bucket",
 			datatype:      "baz1",
 			dtSchemaFiles: []string{"foo1:/path/to/foo1.json", "bar1:/path/to/bar1.json"},
 			want:          "/var/spool/datatypes/baz1.json",
@@ -71,7 +72,7 @@ func TestValidateAndUpload(t *testing.T) { //nolint:paralleltest,funlen
 			name:            "non-existent datatype schema file, should not upload",
 			tblSchemaFile:   "autoload/v0/tables/jostler/foo1.table.json",
 			rmTblSchemaFile: false,
-			bucket:          "fake-bucket",
+			bucket:          "disk-bucket",
 			experiment:      testExperiment,
 			datatype:        testDatatype,
 			dtSchemaFile:    "testdata/datatypes/non-existent.json", // this file doesn't exist
@@ -81,7 +82,7 @@ func TestValidateAndUpload(t *testing.T) { //nolint:paralleltest,funlen
 			name:            "invalid datatype schema file, should not upload",
 			tblSchemaFile:   "autoload/v0/tables/jostler/foo1.table.json",
 			rmTblSchemaFile: false,
-			bucket:          "fake-bucket",
+			bucket:          "disk-bucket",
 			experiment:      testExperiment,
 			datatype:        testDatatype,
 			dtSchemaFile:    "testdata/datatypes/foo1-invalid.json", // this file doesn't exist
@@ -169,10 +170,10 @@ func TestValidateAndUpload(t *testing.T) { //nolint:paralleltest,funlen
 		},
 	}
 
-	// Use a fake GCS implementation that reads from and writes to
-	// the local filesystemi.
+	// Use a local disk storage implementation that mimics downloads
+	// from and uploads to GCS.
 	saveGCSClient := schema.GCSClient
-	schema.GCSClient = testhelper.FakeNewClient
+	schema.GCSClient = testhelper.DiskClient
 	defer func() {
 		schema.GCSClient = saveGCSClient
 		os.RemoveAll("testdata/autoload")

--- a/internal/uploadbundle/uploadbundle.go
+++ b/internal/uploadbundle/uploadbundle.go
@@ -1,6 +1,6 @@
-// Package uploadbundle bundles multiple JSON files on the local
-// filesystem into a single JSON Lines (JSONL) file and uploads the bundle
-// to Google Cloud Storage (GCS).
+// Package uploadbundle implements logic to bundle multiple JSON files
+// on the local filesystem into JSONL bundles and upload them to Google
+// Cloud Storage (GCS).
 //
 // The local files should:
 //
@@ -18,20 +18,37 @@ package uploadbundle
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
 	"path/filepath"
-	"sync"
+	"reflect"
+	"regexp"
+	"strings"
 	"time"
 
+	"github.com/m-lab/jostler/internal/gcs"
+	"github.com/m-lab/jostler/internal/jsonlbundle"
 	"github.com/m-lab/jostler/internal/watchdir"
 )
+
+// DirWatcher defines the interface of a directory watcher.
+type DirWatcher interface {
+	WatchChan() chan watchdir.WatchEvent
+	WatchAckChan() chan<- []string
+	WatchAndNotify(context.Context) error
+}
 
 // UploadBundle defines configuration options and other fields that are
 // common to all instances of JSONL bundles (see jsonlBundle).
 type UploadBundle struct {
-	wdClient      *watchdir.WatchDir  // directory watcher that notifies us
-	gcsConf       GCSConfig           // GCS configuration
-	bundleConf    BundleConfig        // bundle configuration
-	uploadBundles map[string]struct{} // bundles that are being uploaded or were uploaded
+	wdClient      DirWatcher                          // directory watcher that notifies us
+	gcsConf       GCSConfig                           // GCS configuration
+	bundleConf    BundleConfig                        // bundle configuration
+	ageChan       chan *jsonlbundle.JSONLBundle       // notification channel for when bundle reaches maximum age
+	activeBundles map[string]*jsonlbundle.JSONLBundle // bundles that are active
+	uploadBundles map[string]struct{}                 // bundles that are being uploaded or were uploaded
 }
 
 // GCSConfig defines GCS configuration options.
@@ -43,9 +60,10 @@ type UploadBundle struct {
 // Note that while slashes ("/") in GCS object names create the illusion
 // of a directory hierarchy, GCS has a flat namesapce.
 type GCSConfig struct {
-	Bucket  string // GCS bucket name
-	DataDir string // see the above comment
-	BaseID  string // see the above comment
+	Bucket    string // GCS bucket name
+	DataDir   string // see the above comment
+	BaseID    string // see the above comment
+	gcsClient gcs.GCSClient
 }
 
 // BundleConfig defines bundle configuration options.
@@ -54,10 +72,27 @@ type BundleConfig struct {
 	DataDir  string        // path to datatype subdirectory on local disk (e.g., /var/spool/<experiment>/<datatype>)
 	SizeMax  uint          // bundle will be uploaded when it reaches this size
 	AgeMax   time.Duration // bundle will be uploaded when it reaches this age
-	NoRm     bool          // XXX debugging support - delete when done
 }
 
-var verbose = func(fmt string, args ...interface{}) {}
+var (
+	weekDays   = 7   // entries in the map
+	numUploads = 100 // concurrent uploads
+
+	ErrConfig       = errors.New("invalid configuration")
+	ErrNotInDataDir = errors.New("is not in data directory")
+	ErrTooShort     = errors.New("is too short")
+	ErrInvalidChars = errors.New("has invalid characters")
+	ErrDotDot       = errors.New("includes '..'")
+	ErrDateDir      = errors.New("is not in .../yyyy/mm/dd/... format")
+	ErrDotFile      = errors.New("starts with '.'")
+	ErrNotRegular   = errors.New("is not a regular file")
+	ErrEmpty        = errors.New("is empty")
+	ErrTooBig       = errors.New("is too big to fit in a bundle")
+
+	// Testing and debugging support.
+	GCSClient = gcs.NewClient
+	verbose   = func(fmt string, args ...interface{}) {}
+)
 
 // Verbose provides a convenient way for the caller to enable verbose
 // printing and control its format (mostly for debugging).
@@ -67,35 +102,224 @@ func Verbose(v func(string, ...interface{})) {
 
 // New returns a new UploadBundle instance.  Clients call this function
 // for each datatype.
-func New(wdClient *watchdir.WatchDir, gcsConf GCSConfig, bundleConf BundleConfig) (*UploadBundle, error) {
+func New(ctx context.Context, wdClient DirWatcher, gcsConf GCSConfig, bundleConf BundleConfig) (*UploadBundle, error) {
+	if wdClient == nil || reflect.ValueOf(wdClient).IsNil() {
+		return nil, fmt.Errorf("%w: nil watchdir client", ErrConfig)
+	}
+	if gcsConf.Bucket == "" || gcsConf.DataDir == "" || gcsConf.BaseID == "" || bundleConf.DataDir == "" {
+		return nil, fmt.Errorf("%w: empty string in parameters", ErrConfig)
+	}
+	gcsClient, err := GCSClient(ctx, gcsConf.Bucket)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCS client: %w", err)
+	}
 	ub := &UploadBundle{
 		wdClient:      wdClient,
 		gcsConf:       gcsConf,
 		bundleConf:    bundleConf,
-		uploadBundles: make(map[string]struct{}, 1000),
+		ageChan:       make(chan *jsonlbundle.JSONLBundle),
+		activeBundles: make(map[string]*jsonlbundle.JSONLBundle, weekDays),
+		uploadBundles: make(map[string]struct{}, numUploads),
 	}
+	ub.gcsConf.gcsClient = gcsClient
 	ub.bundleConf.DataDir = filepath.Clean(ub.bundleConf.DataDir)
 	return ub, nil
 }
 
-// BundleAndUpload is a stub function.
+// BundleAndUpload continuously reads from two channels until its context
+// is canceled.  One channel provides pathnames to new or potentially
+// missed files that should be added to the bundle.  The other channel
+// provides timer notifications for in-memory bundles that have reached
+// their maximum age and should be uploaded to GCS.
 func (ub *UploadBundle) BundleAndUpload(ctx context.Context) error {
-	<-ctx.Done()
-	verbose("bundle and upload context canceled")
+	verbose("bundling and uploading files in %v", ub.bundleConf.DataDir)
+	done := false
+	for !done {
+		select {
+		case <-ctx.Done():
+			verbose("'bundle and upload' context canceled for %v", ub.bundleConf.DataDir)
+			done = true
+		case watchEvent, chOpen := <-ub.wdClient.WatchChan():
+			if !chOpen {
+				verbose("watch channel closed")
+				done = true
+				break
+			}
+			// A new or missing JSON file was detected.
+			ub.bundleFile(ctx, watchEvent.Path)
+		case jb, chOpen := <-ub.ageChan:
+			if !chOpen {
+				verbose("age channel closed")
+				done = true
+				break
+			}
+			// A bundle reached its maximum age.
+			ub.uploadAgedBundle(ctx, jb)
+		}
+	}
 	return nil
 }
 
-// UploadActiveBundles uploads all active bundles regardless of their
-// age and size.  This is primarily meant to provide a graceful shutdown.
-func (ub *UploadBundle) UploadActiveBundles(ctx context.Context, wg *sync.WaitGroup) {
-	defer wg.Done()
-	verbose("start uploading all active %v bundles", ub.bundleConf.Datatype)
-	if ub.bundleConf.Datatype == "foo1" {
-		verbose("waiting 2 seconds for foo1 bundles")
-		time.Sleep(2 * time.Second)
-	} else {
-		verbose("waiting 3 seconds for bar1 bundles")
-		time.Sleep(3 * time.Second)
+// bundleFile adds the given file to a bundle if it's a valid JSON file and
+// is has not been bundled before.
+func (ub *UploadBundle) bundleFile(ctx context.Context, fullPath string) {
+	// Validate the file's pathname and get its date subdirectory
+	// and size.
+	dateSubdir, fileSize, err := ub.fileDetails(fullPath)
+	if err != nil {
+		verbose("WARNING: ignoring %v: %v", fullPath, err)
+		return
 	}
-	verbose("successfully uploaded all active %v bundles", ub.bundleConf.Datatype)
+	verbose("%v %v bytes", fullPath, fileSize)
+
+	// Is there an active bundle that this file belongs to?
+	jb := ub.activeBundles[dateSubdir]
+	if jb != nil {
+		// Sanity check.
+		if jb.HasFile(fullPath) {
+			log.Printf("INTERNAL ERROR: %v already in active %v", fullPath, jb.Description())
+		}
+		// Check if there's enough room for this file in the active
+		// bundle.  If not, upload this bundle and instantiate a
+		// new one.
+		if jb.Size+uint(fileSize) > ub.bundleConf.SizeMax {
+			verbose("not enough room in active %v for %v", jb.Description(), fullPath)
+			ub.uploadBundle(ctx, jb)
+			jb = nil
+		}
+	}
+	if jb == nil {
+		jb = ub.newJSONLBundle(dateSubdir)
+	}
+	// Add the contents of this file to the bundle.
+	if err := jb.AddFile(fullPath); err != nil {
+		log.Printf("ERROR: failed to add file to active bundle: %v\n", err)
+	} else {
+		verbose("active %v has %v bytes", jb.Description(), jb.Size)
+	}
+}
+
+// fileDetails first verifies fullPath follows M-Lab's conventions
+// /cache/data/<experiment>/<datatype>/<yyyy>/<mm>/<dd>/<filename>
+// and is a regular file.  Then it makes sure it's not too big.
+// If all is OK, it returns the date component of the file's pathname
+// ("yyyy/mm/dd") and the file size.
+func (ub *UploadBundle) fileDetails(fullPath string) (string, int64, error) {
+	cleanFilePath := filepath.Clean(fullPath)
+	dataDir := ub.bundleConf.DataDir
+	if !strings.HasPrefix(cleanFilePath, dataDir) {
+		return "", 0, fmt.Errorf("%v: %w", cleanFilePath, ErrNotInDataDir)
+	}
+	if len(cleanFilePath) <= len(dataDir) {
+		return "", 0, fmt.Errorf("%v: %w", cleanFilePath, ErrTooShort)
+	}
+	pathName := regexp.MustCompile(`[^a-zA-Z0-9/:._-]`)
+	if pathName.MatchString(cleanFilePath) {
+		return "", 0, fmt.Errorf("%v: %w", cleanFilePath, ErrInvalidChars)
+	}
+	if strings.Contains(cleanFilePath, "..") {
+		return "", 0, fmt.Errorf("%v: %w", cleanFilePath, ErrDotDot)
+	}
+	dateSubdir, filename := filepath.Split(cleanFilePath[len(dataDir):])
+	yyyymmdd := regexp.MustCompile(`/20[0-9][0-9]/[0-9]{2}/[0-9]{2}/`)
+	if len(dateSubdir) != 12 || !yyyymmdd.MatchString(dateSubdir) {
+		return "", 0, fmt.Errorf("%v: %w", cleanFilePath, ErrDateDir)
+	}
+	if strings.HasPrefix(filename, ".") {
+		return "", 0, fmt.Errorf("%v: %w", filename, ErrDotFile)
+	}
+	fi, err := os.Stat(fullPath)
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to stat: %w", err)
+	}
+	if !fi.Mode().IsRegular() {
+		return "", 0, fmt.Errorf("%v: %w", filename, ErrNotRegular)
+	}
+	if uint(fi.Size()) == 0 {
+		return "", 0, fmt.Errorf("%v: %w", filename, ErrEmpty)
+	}
+	if uint(fi.Size()) > ub.bundleConf.SizeMax {
+		return "", 0, fmt.Errorf("%v: %w", filename, ErrTooBig)
+	}
+	return dateSubdir[1:11], fi.Size(), nil
+}
+
+// newJSONLBundle creates and returns a new active bundle instance.
+func (ub *UploadBundle) newJSONLBundle(dateSubdir string) *jsonlbundle.JSONLBundle {
+	// Sanity check: make sure we don't already have a bundle for
+	// the given date.
+	if jb, ok := ub.activeBundles[dateSubdir]; ok {
+		if dateSubdir == jb.DateSubdir {
+			log.Printf("INTERNAL ERROR: an active %v already exists", jb.Description())
+		}
+		log.Printf("INTERNAL ERROR: key %v returned active %v", dateSubdir, jb.Description())
+	}
+
+	jb := jsonlbundle.New(ub.gcsConf.Bucket, ub.gcsConf.DataDir, ub.gcsConf.BaseID, ub.bundleConf.Datatype, dateSubdir)
+	ub.activeBundles[dateSubdir] = jb
+	verbose("created active %v", jb.Description())
+	time.AfterFunc(ub.bundleConf.AgeMax, func() {
+		ub.ageChan <- jb
+	})
+	log.Printf("started age timer to go off in %v for active %v\n", ub.bundleConf.AgeMax, jb.Description())
+	return jb
+}
+
+// uploadAgedBundle uploads the given bundle if it is still active.
+// Otherwise, we should delete it from the upload bundles map because
+// we received its age timer.
+func (ub *UploadBundle) uploadAgedBundle(ctx context.Context, jb *jsonlbundle.JSONLBundle) {
+	verbose("age timer went off for %v", jb.Description())
+	if _, ok := ub.uploadBundles[jb.Timestamp]; ok {
+		verbose("%v is already uploaded or being uploaded now", jb.Description())
+		delete(ub.uploadBundles, jb.Timestamp)
+		return
+	}
+	ub.uploadBundle(ctx, jb)
+}
+
+// uploadBundle adds the given bundle (which should be active) to the
+// upload bundles map, deletes it from the active bundles map, and start
+// the uploads process to GCS in the background.
+func (ub *UploadBundle) uploadBundle(ctx context.Context, jb *jsonlbundle.JSONLBundle) {
+	// Sanity check.
+	if _, ok := ub.activeBundles[jb.DateSubdir]; !ok {
+		log.Printf("INTERNAL ERROR: %v not in active bundles map", jb.Description())
+	}
+
+	// Add the bundle to upload bundles map.
+	ub.uploadBundles[jb.Timestamp] = struct{}{}
+	// Delete the bundle from active bundles map.
+	delete(ub.activeBundles, jb.DateSubdir)
+
+	// Start the upload process in the background and acknowledge
+	// the files of this bundle with the directory watcher.
+	go ub.uploadInBackground(ctx, jb, true)
+}
+
+// upload starts the process of uploading the specified measurement data
+// (JSONL bundle) and its associated index in the background.
+func (ub *UploadBundle) uploadInBackground(ctx context.Context, jb *jsonlbundle.JSONLBundle, ack bool) {
+	gcsClient := ub.gcsConf.gcsClient
+	go func(jb *jsonlbundle.JSONLBundle) {
+		// Upload the bundle.
+		objPath := filepath.Join(jb.ObjDir, jb.ObjName)
+		contents := []byte(strings.Join(jb.Lines, "\n"))
+		if err := gcsClient.Upload(ctx, objPath, contents); err != nil {
+			log.Printf("ERROR: failed to upload bundle %v: %v\n", jb.Description(), err)
+			return
+		}
+		objPath = filepath.Join(jb.ObjDir, jb.IdxName)
+		contents = []byte(strings.Join(jb.FullPaths, "\n"))
+		if err := gcsClient.Upload(ctx, objPath, contents); err != nil {
+			log.Printf("ERROR: failed to upload index for bundle %v: %v\n", jb.Description(), err)
+			return
+		}
+		// Remove uploaded files from the local filesystem.
+		jb.RemoveLocalFiles()
+		// Tell directory watcher we're done with these files.
+		if ack {
+			ub.wdClient.WatchAckChan() <- append(jb.FullPaths, jb.BadFiles...)
+		}
+	}(jb)
 }

--- a/internal/uploadbundle/uploadbundle.go
+++ b/internal/uploadbundle/uploadbundle.go
@@ -68,10 +68,12 @@ type GCSConfig struct {
 
 // BundleConfig defines bundle configuration options.
 type BundleConfig struct {
-	Datatype string        // datatype (e.g., scamper1)
-	DataDir  string        // path to datatype subdirectory on local disk (e.g., /var/spool/<experiment>/<datatype>)
-	SizeMax  uint          // bundle will be uploaded when it reaches this size
-	AgeMax   time.Duration // bundle will be uploaded when it reaches this age
+	Version   string        // version of this program producing the bundle (e.g., v0.1.7)
+	GitCommit string        // git commit SHA1 of this program (e.g., 2abe77f)
+	Datatype  string        // datatype (e.g., scamper1)
+	DataDir   string        // path to datatype subdirectory on local disk (e.g., /var/spool/<experiment>/<datatype>)
+	SizeMax   uint          // bundle will be uploaded when it reaches this size
+	AgeMax    time.Duration // bundle will be uploaded when it reaches this age
 }
 
 var (
@@ -192,7 +194,7 @@ func (ub *UploadBundle) bundleFile(ctx context.Context, fullPath string) {
 		jb = ub.newJSONLBundle(dateSubdir)
 	}
 	// Add the contents of this file to the bundle.
-	if err := jb.AddFile(fullPath); err != nil {
+	if err := jb.AddFile(fullPath, ub.bundleConf.Version, ub.bundleConf.GitCommit); err != nil {
 		log.Printf("ERROR: failed to add file to active bundle: %v\n", err)
 	} else {
 		verbose("active %v has %v bytes", jb.Description(), jb.Size)

--- a/internal/uploadbundle/uploadbundle_test.go
+++ b/internal/uploadbundle/uploadbundle_test.go
@@ -1,0 +1,239 @@
+package uploadbundle //nolint:testpackage
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/m-lab/jostler/internal/testhelper"
+	"github.com/m-lab/jostler/internal/watchdir"
+)
+
+func TestVerbose(t *testing.T) { //nolint:paralleltest
+	Verbose(func(fmt string, args ...interface{}) {})
+}
+
+func TestNew(t *testing.T) { //nolint:paralleltest
+	wdClient, err := testhelper.WatchDirNew("/some/path")
+	if err != nil {
+		t.Fatalf("testhelper.WatchDirNew() = %v, want nil", err)
+	}
+	tests := []struct {
+		name          string
+		wdClient      *testhelper.WatchDir
+		gcsBucket     string
+		gcsDataDir    string
+		gcsBaseID     string
+		bundleDataDir string
+		wantErr       error
+	}{
+		{
+			name:          "nil wdClient",
+			wdClient:      nil,
+			gcsBucket:     "some-bucket",
+			gcsDataDir:    "some/path/in/gcs",
+			gcsBaseID:     "some-string",
+			bundleDataDir: "/some/path",
+			wantErr:       ErrConfig,
+		},
+		{
+			name:          "empty string gcsBucket",
+			wdClient:      wdClient,
+			gcsBucket:     "",
+			gcsDataDir:    "some/path/in/gcs",
+			gcsBaseID:     "some-string",
+			bundleDataDir: "/some/path",
+			wantErr:       ErrConfig,
+		},
+		{
+			name:          "empty string gcsDataDir",
+			wdClient:      wdClient,
+			gcsBucket:     "some-bucket",
+			gcsDataDir:    "",
+			gcsBaseID:     "some-string",
+			bundleDataDir: "/some/path",
+			wantErr:       ErrConfig,
+		},
+		{
+			name:          "empty string gcsBaseID",
+			wdClient:      wdClient,
+			gcsBucket:     "some-bucket",
+			gcsDataDir:    "some/path/in/gcs",
+			gcsBaseID:     "",
+			bundleDataDir: "/some/path",
+			wantErr:       ErrConfig,
+		},
+		{
+			name:          "empty string bundleDataDir",
+			wdClient:      wdClient,
+			gcsBucket:     "some-bucket",
+			gcsDataDir:    "some/path/in/gcs",
+			gcsBaseID:     "some-string",
+			bundleDataDir: "",
+			wantErr:       ErrConfig,
+		},
+		{
+			name:          "valid args",
+			wdClient:      wdClient,
+			gcsBucket:     "newclient",
+			gcsDataDir:    "some/path/in/gcs",
+			gcsBaseID:     "some-string",
+			bundleDataDir: "/some/path",
+			wantErr:       nil,
+		},
+	}
+	saveGCSClient := GCSClient
+	GCSClient = testhelper.DiskClient
+	defer func() {
+		GCSClient = saveGCSClient
+	}()
+	for i, test := range tests {
+		gcsConf := GCSConfig{
+			Bucket:  test.gcsBucket,
+			DataDir: test.gcsDataDir,
+			BaseID:  test.gcsBaseID,
+		}
+		bundleConf := BundleConfig{
+			Datatype: "foo1",
+			DataDir:  test.bundleDataDir,
+			SizeMax:  20 * 1024 * 1024,
+			AgeMax:   1 * time.Hour,
+		}
+		var s string
+		if test.wantErr == nil {
+			s = "should succeed"
+		} else {
+			s = "should fail"
+		}
+		t.Logf("%s>>> test %02d: %s: %v%s", testhelper.ANSIPurple, i, s, test.name, testhelper.ANSIEnd)
+		_, gotErr := New(context.Background(), test.wdClient, gcsConf, bundleConf)
+		if gotErr == nil && test.wantErr == nil {
+			continue
+		}
+		if (gotErr != nil && test.wantErr == nil) ||
+			(gotErr == nil && test.wantErr != nil) ||
+			!errors.Is(gotErr, test.wantErr) {
+			t.Fatalf("New() = %v, want %v", err, test.wantErr)
+		}
+	}
+}
+
+func TestBundleAndUploadCtx(t *testing.T) { //nolint:paralleltest
+	saveGCSClient := GCSClient
+	GCSClient = testhelper.DiskClient
+	defer func() {
+		GCSClient = saveGCSClient
+	}()
+	Verbose(testhelper.VLogf)
+
+	// BundleAndUpload() returns when its context is canceled.
+	setupDataDir(t)
+	sizeMax := uint(100)
+	ageMax := 2 * time.Second
+	_, ubClient := setupClients(t, sizeMax, ageMax)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-time.After(ageMax + 2*time.Second)
+		t.Logf(">>> canceling context")
+		cancel()
+	}()
+	if err := ubClient.BundleAndUpload(ctx); err != nil {
+		t.Fatalf("New() = %v, want nil", err)
+	}
+}
+
+func TestBundleAndUploadTooBig(t *testing.T) { //nolint:paralleltest
+	saveGCSClient := GCSClient
+	GCSClient = testhelper.DiskClient
+	defer func() {
+		GCSClient = saveGCSClient
+	}()
+	Verbose(testhelper.VLogf)
+
+	// Force not enough room in the bundle by setting sizeMax to a
+	// ridiculously small value.
+	setupDataDir(t)
+	sizeMax := uint(1)
+	ageMax := 2 * time.Second
+	_, ubClient := setupClients(t, sizeMax, ageMax)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-time.After(2 * ageMax)
+		t.Logf(">>> canceling context")
+		cancel()
+	}()
+	if err := ubClient.BundleAndUpload(ctx); err != nil {
+		t.Fatalf("New() = %v, want nil", err)
+	}
+}
+
+func setupDataDir(t *testing.T) {
+	t.Helper()
+	if err := os.MkdirAll("testdata/spool/jostler/foo1/2022/11/09", 0o755); err != nil {
+		t.Fatalf("os.MkdirAll() = %v, want nil", err)
+	}
+	for _, file := range []struct {
+		name     string
+		contents string
+	}{
+		{name: "nil.json", contents: ""},
+		{name: "invalid.json", contents: `{ "Field1": 1 "Field2": 0.1 "NMSVersion": "v1.0.0" }`},
+		{name: "valid.json", contents: `{ "Field1": 1, "Field2": 0.1, "NMSVersion": "v1.0.0" }`},
+	} {
+		f := filepath.Join("testdata/spool/jostler/foo1/2022/11/09/", file.name)
+		if err := os.WriteFile(f, []byte(file.contents), 0o644); err != nil {
+			t.Fatalf("os.WriteFile() = %v, want nil", err)
+		}
+	}
+	if err := os.MkdirAll("testdata/spool/jostler/foo1/2022/11/09/dir.json", 0o755); err != nil {
+		t.Fatalf("os.MkdirAll() = %v, want nil", err)
+	}
+}
+
+func setupClients(t *testing.T, sizeMax uint, ageMax time.Duration) (*testhelper.WatchDir, *UploadBundle) {
+	t.Helper()
+	// Create a directory watcher client (local disk).
+	wdClient, err := testhelper.WatchDirNew("/some/path")
+	if err != nil {
+		t.Fatalf("testhelper.WatchDirNew() = %v, want nil", err)
+	}
+	// Send WatchEvents through WatchChan for the following paths.
+	paths := []string{
+		"j.json",
+		"testdata/spool/jostler/foo1/../j.json",
+		"testdata/spool/jostler/foo1",
+		"testdata/spool/jostler/foo1/2022/11/09/j,json",
+		"testdata/spool/jostler/foo1/2022/11/09/j..json",
+		"testdata/spool/jostler/foo1/2022/11/9/j.json",
+		"testdata/spool/jostler/foo1/2022/11/09/.j.json",
+		"testdata/spool/jostler/foo1/2022/11/09/non-existent.json",
+		"testdata/spool/jostler/foo1/2022/11/09/dir.json",
+		"testdata/spool/jostler/foo1/2022/11/09/nil.json",
+		"testdata/spool/jostler/foo1/2022/11/09/invalid.json",
+		"testdata/spool/jostler/foo1/2022/11/09/valid.json",
+	}
+	for _, path := range paths {
+		wdClient.WatchChan() <- watchdir.WatchEvent{Path: path, Missed: false}
+	}
+
+	// Create a bundler and uploader client.
+	gcsConf := GCSConfig{
+		Bucket:  "newclient,upload",
+		DataDir: "testdata/autoload/v0",
+		BaseID:  "some-string",
+	}
+	bundleConf := BundleConfig{
+		Datatype: "foo1",
+		DataDir:  "testdata/spool/jostler/foo1",
+		SizeMax:  sizeMax,
+		AgeMax:   ageMax,
+	}
+	ubClient, err := New(context.Background(), wdClient, gcsConf, bundleConf)
+	if err != nil {
+		t.Fatalf("New() = %v, want nil", err)
+	}
+	return wdClient, ubClient
+}


### PR DESCRIPTION
This commit splits the uploadbundle package into two packages: uploadbundle and jsonlbundle.

To perform unit, integration, and e2e testing, this commit also includes changes to the testhelper package (as its name suggests, the testhelper package is solely for testing purposes and its code is not compiled into the build).
    
All changes successfully pass golangci-lint and go test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/jostler/13)
<!-- Reviewable:end -->
