### PR TITLE
Rework code to use interfaces instead of function variables

### DIFF
--- a/cmd/jostler/cli.go
+++ b/cmd/jostler/cli.go
@@ -39,7 +39,7 @@ var (
 	// Flags related to program's execution.
 	local        bool
 	verbose      bool
-	noGCS        bool
+	localDisk    bool
 	testInterval time.Duration
 
 	// Errors related to command line parsing and validation.
@@ -76,7 +76,7 @@ func initFlags() {
 	// Flags related to program's execution.
 	flag.BoolVar(&local, "local", false, "run locally and create schema files for each datatype")
 	flag.BoolVar(&verbose, "verbose", false, "enable verbose mode")
-	flag.BoolVar(&noGCS, "no-gcs", false, "use local disk storage instead of cloud storage (for test purposes only)")
+	flag.BoolVar(&localDisk, "local-disk", false, "use local disk storage instead of cloud storage (for test purposes only)")
 	flag.DurationVar(&testInterval, "test-interval", 0, "time interval to stop running (for test purposes only)")
 
 	flag.Var(&dtSchemaFiles, "datatype-schema-file", "schema for each datatype in the format <datatype>:<pathname>")

--- a/cmd/jostler/main.go
+++ b/cmd/jostler/main.go
@@ -115,11 +115,11 @@ func localMode() error {
 func daemonMode() error {
 	mainCtx, mainCancel := context.WithCancel(context.Background())
 	// Create a storage client.
-	// The noGCS flag is meant for e2e testing where we want to read
+	// The localDisk flag is meant for e2e testing where we want to read
 	// from and write to the local disk storage instead of cloud storage.
 	var stClient schema.DownloaderUploader
 	var err error
-	if noGCS {
+	if localDisk {
 		stClient, err = testhelper.NewClient(mainCtx, bucket)
 	} else {
 		stClient, err = gcs.NewClient(mainCtx, bucket)
@@ -200,10 +200,10 @@ func startUploader(mainCtx context.Context, mainCancel context.CancelFunc, statu
 	}
 
 	// Create a storage client.
-	// The noGCS flag is meant for e2e testing where we want to read
+	// The localDisk flag is meant for e2e testing where we want to read
 	// from and write to the local disk storage instead of cloud storage.
 	var stClient uploadbundle.Uploader
-	if noGCS {
+	if localDisk {
 		stClient, err = testhelper.NewClient(mainCtx, bucket)
 	} else {
 		stClient, err = gcs.NewClient(mainCtx, bucket)

--- a/cmd/jostler/main.go
+++ b/cmd/jostler/main.go
@@ -52,6 +52,7 @@ import (
 	"github.com/m-lab/go/host"
 	"github.com/rjeczalik/notify"
 
+	"github.com/m-lab/jostler/internal/gcs"
 	"github.com/m-lab/jostler/internal/schema"
 	"github.com/m-lab/jostler/internal/testhelper"
 	"github.com/m-lab/jostler/internal/uploadbundle"
@@ -76,12 +77,6 @@ func main() {
 	log.SetFlags(log.Ltime)
 	if err := parseAndValidateCLI(); err != nil {
 		fatal(err)
-	}
-	// The noGCS flag is meant for e2e testing where we want to read
-	// from and write to the local disk storage instead of cloud storage.
-	if noGCS {
-		schema.GCSClient = testhelper.DiskNewClient
-		uploadbundle.GCSClient = testhelper.DiskNewClient
 	}
 
 	if local {
@@ -118,24 +113,39 @@ func localMode() error {
 // individual measurement data files in JSON format into JSONL bundles and
 // upload to GCS.
 func daemonMode() error {
+	mainCtx, mainCancel := context.WithCancel(context.Background())
+	// Create a storage client.
+	// The noGCS flag is meant for e2e testing where we want to read
+	// from and write to the local disk storage instead of cloud storage.
+	var stClient schema.DownloaderUploader
+	var err error
+	if noGCS {
+		stClient, err = testhelper.NewClient(mainCtx, bucket)
+	} else {
+		stClient, err = gcs.NewClient(mainCtx, bucket)
+	}
+	if err != nil {
+		mainCancel()
+		return fmt.Errorf("failed to create storage client: %w", err)
+	}
 	// Validate table schemas are backward compatible and upload the
 	// ones are a superset of the previous table.
 	for _, datatype := range datatypes {
 		dtSchemaFile := schema.PathForDatatype(datatype, dtSchemaFiles)
-		if err := schema.ValidateAndUpload(bucket, experiment, datatype, dtSchemaFile); err != nil {
+		if err = schema.ValidateAndUpload(stClient, bucket, experiment, datatype, dtSchemaFile); err != nil {
+			mainCancel()
 			return fmt.Errorf("%v: %w", datatype, err)
 		}
 	}
 
-	watchEvents := []notify.Event{notify.InCloseWrite, notify.InMovedTo}
-	mainCtx, mainCancel := context.WithCancel(context.Background())
-	// defer mainCancel()
 	// For each datatype, start a directory watcher and a bundle
 	// uploader.
+	watchEvents := []notify.Event{notify.InCloseWrite, notify.InMovedTo}
 	watcherStatus := make(chan error)
 	uploaderStatus := make(chan error)
 	for _, datatype := range datatypes {
-		wdClient, err := startWatcher(mainCtx, mainCancel, watcherStatus, datatype, watchEvents)
+		var wdClient *watchdir.WatchDir
+		wdClient, err = startWatcher(mainCtx, mainCancel, watcherStatus, datatype, watchEvents)
 		if err != nil {
 			return err
 		}
@@ -156,7 +166,6 @@ func daemonMode() error {
 	// to close or if the main context is explicitly canceled, the
 	// goroutines created in startWatcher() and startBundleUploader()
 	// will terminate and the following Wait() returns.
-	var err error
 	select {
 	case err = <-watcherStatus:
 	case err = <-uploaderStatus:
@@ -190,10 +199,23 @@ func startUploader(mainCtx context.Context, mainCancel context.CancelFunc, statu
 		return nil, fmt.Errorf("failed to parse hostname: %w", err)
 	}
 
+	// Create a storage client.
+	// The noGCS flag is meant for e2e testing where we want to read
+	// from and write to the local disk storage instead of cloud storage.
+	var stClient uploadbundle.Uploader
+	if noGCS {
+		stClient, err = testhelper.NewClient(mainCtx, bucket)
+	} else {
+		stClient, err = gcs.NewClient(mainCtx, bucket)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to create storage client: %w", err)
+	}
 	gcsConf := uploadbundle.GCSConfig{
-		Bucket:  bucket,
-		DataDir: filepath.Join(gcsHomeDir, experiment, datatype),
-		BaseID:  fmt.Sprintf("%s-%s-%s-%s", datatype, nameParts.Machine, nameParts.Site, experiment),
+		GCSClient: stClient,
+		Bucket:    bucket,
+		DataDir:   filepath.Join(gcsHomeDir, experiment, datatype),
+		BaseID:    fmt.Sprintf("%s-%s-%s-%s", datatype, nameParts.Machine, nameParts.Site, experiment),
 	}
 	bundleConf := uploadbundle.BundleConfig{
 		Version:   version,

--- a/cmd/jostler/main_test.go
+++ b/cmd/jostler/main_test.go
@@ -176,12 +176,7 @@ func TestCLI(t *testing.T) { //nolint:funlen,paralleltest
 			},
 		},
 	}
-	// Use a local disk storage implementation that mimics downloads
-	// from and uploads to GCS.
-	saveGCSClient := schema.GCSClient
-	schema.GCSClient = testhelper.DiskNewClient
 	defer func() {
-		schema.GCSClient = saveGCSClient
 		os.RemoveAll("foo1.json")
 		os.RemoveAll("testdata/autoload")
 	}()
@@ -197,6 +192,9 @@ func TestCLI(t *testing.T) { //nolint:funlen,paralleltest
 		}
 		t.Logf("%s>>> test %02d: %s: %v%s", testhelper.ANSIPurple, i, s, test.name, testhelper.ANSIEnd)
 		args := test.args
+		// Use a local disk storage implementation that mimics downloads
+		// from and uploads to GCS.
+		args = append(args, "-no-gcs")
 		if testing.Verbose() {
 			args = append(args, "-verbose")
 		}

--- a/cmd/jostler/main_test.go
+++ b/cmd/jostler/main_test.go
@@ -194,7 +194,7 @@ func TestCLI(t *testing.T) { //nolint:funlen,paralleltest
 		args := test.args
 		// Use a local disk storage implementation that mimics downloads
 		// from and uploads to GCS.
-		args = append(args, "-no-gcs")
+		args = append(args, "-local-disk")
 		if testing.Verbose() {
 			args = append(args, "-verbose")
 		}

--- a/internal/gcs/gcs.go
+++ b/internal/gcs/gcs.go
@@ -17,8 +17,6 @@ import (
 )
 
 type StorageClient struct {
-	// Download     func(context.Context, string) ([]byte, error)
-	// Upload       func(context.Context, string, []byte) error
 	bucket       string
 	client       stiface.Client
 	bucketHandle stiface.BucketHandle

--- a/internal/gcs/gcs.go
+++ b/internal/gcs/gcs.go
@@ -17,8 +17,8 @@ import (
 )
 
 type StorageClient struct {
-	Download     func(context.Context, string) ([]byte, error)
-	Upload       func(context.Context, string, []byte) error
+	// Download     func(context.Context, string) ([]byte, error)
+	// Upload       func(context.Context, string, []byte) error
 	bucket       string
 	client       stiface.Client
 	bucketHandle stiface.BucketHandle
@@ -57,18 +57,15 @@ func NewClient(ctx context.Context, bucket string) (*StorageClient, error) {
 }
 
 func newStorageClient(bucket string, client stiface.Client, bucketHandle stiface.BucketHandle) *StorageClient {
-	s := StorageClient{
+	return &StorageClient{
 		bucket:       bucket,
 		client:       client,
 		bucketHandle: bucketHandle,
 	}
-	s.Download = s.download
-	s.Upload = s.upload
-	return &s
 }
 
-// download downloads the specified object from GCS.
-func (s *StorageClient) download(ctx context.Context, objPath string) ([]byte, error) {
+// Download downloads the specified object from GCS.
+func (s *StorageClient) Download(ctx context.Context, objPath string) ([]byte, error) {
 	verbose("downloading '%v:%v'", s.bucket, objPath)
 	storageCtx, storageCancel := context.WithTimeout(ctx, downloadTimeout)
 	defer storageCancel()
@@ -86,12 +83,12 @@ func (s *StorageClient) download(ctx context.Context, objPath string) ([]byte, e
 	return contents, nil
 }
 
-// upload uploads the specified contents to GCS.
+// Upload uploads the specified contents to GCS.
 //
 // Methods in the storage package may retry calls that fail with transient
 // errors. Retrying continues indefinitely unless the controlling context is
 // canceled, the client is closed, or a non-transient error is received.
-func (s *StorageClient) upload(ctx context.Context, objPath string, contents []byte) error {
+func (s *StorageClient) Upload(ctx context.Context, objPath string, contents []byte) error {
 	verbose("uploading '%v:%v'", s.bucket, objPath)
 	obj := s.bucketHandle.Object(objPath)
 	storageCtx, storageCancel := context.WithTimeout(ctx, uploadTimeout)

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -2,6 +2,7 @@
 package schema_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -72,7 +73,7 @@ func TestValidateAndUpload(t *testing.T) { //nolint:paralleltest,funlen
 			name:            "non-existent datatype schema file, should not upload",
 			tblSchemaFile:   "autoload/v0/tables/jostler/foo1.table.json",
 			rmTblSchemaFile: false,
-			bucket:          "disk-bucket",
+			bucket:          "newclient",
 			experiment:      testExperiment,
 			datatype:        testDatatype,
 			dtSchemaFile:    "testdata/datatypes/non-existent.json", // this file doesn't exist
@@ -82,7 +83,7 @@ func TestValidateAndUpload(t *testing.T) { //nolint:paralleltest,funlen
 			name:            "invalid datatype schema file, should not upload",
 			tblSchemaFile:   "autoload/v0/tables/jostler/foo1.table.json",
 			rmTblSchemaFile: false,
-			bucket:          "disk-bucket",
+			bucket:          "newclient",
 			experiment:      testExperiment,
 			datatype:        testDatatype,
 			dtSchemaFile:    "testdata/datatypes/foo1-invalid.json", // this file doesn't exist
@@ -170,12 +171,7 @@ func TestValidateAndUpload(t *testing.T) { //nolint:paralleltest,funlen
 		},
 	}
 
-	// Use a local disk storage implementation that mimics downloads
-	// from and uploads to GCS.
-	saveGCSClient := schema.GCSClient
-	schema.GCSClient = testhelper.DiskNewClient
 	defer func() {
-		schema.GCSClient = saveGCSClient
 		os.RemoveAll("testdata/autoload")
 	}()
 	for i, test := range tests {
@@ -189,7 +185,16 @@ func TestValidateAndUpload(t *testing.T) { //nolint:paralleltest,funlen
 			s = "should fail"
 		}
 		t.Logf("%s>>> test %02d: %s: %v%s", testhelper.ANSIPurple, i, s, test.name, testhelper.ANSIEnd)
-		gotErr := schema.ValidateAndUpload(test.bucket, test.experiment, test.datatype, test.dtSchemaFile)
+		// Use a local disk storage implementation that mimics downloads
+		// from and uploads to GCS.
+		stClient, err := testhelper.NewClient(context.Background(), test.bucket)
+		if err != nil {
+			if strings.Contains(err.Error(), test.wantErr.Error()) {
+				continue // we expected this error
+			}
+			t.Fatalf("testhelper.NewClient() = %v, wanted nil", err)
+		}
+		gotErr := schema.ValidateAndUpload(stClient, test.bucket, test.experiment, test.datatype, test.dtSchemaFile)
 		t.Logf("%s>>> gotErr=%v%s\n\n", testhelper.ANSIPurple, gotErr, testhelper.ANSIEnd)
 		if gotErr == nil && test.wantErr == nil {
 			continue

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -3,6 +3,7 @@ package schema_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -189,7 +190,7 @@ func TestValidateAndUpload(t *testing.T) { //nolint:paralleltest,funlen
 		// from and uploads to GCS.
 		stClient, err := testhelper.NewClient(context.Background(), test.bucket)
 		if err != nil {
-			if strings.Contains(err.Error(), test.wantErr.Error()) {
+			if errors.Is(err, test.wantErr) {
 				continue // we expected this error
 			}
 			t.Fatalf("testhelper.NewClient() = %v, wanted nil", err)

--- a/internal/uploadbundle/uploadbundle_test.go
+++ b/internal/uploadbundle/uploadbundle_test.go
@@ -85,16 +85,16 @@ func TestNew(t *testing.T) { //nolint:paralleltest
 			wantErr:       nil,
 		},
 	}
-	saveGCSClient := GCSClient
-	GCSClient = testhelper.DiskNewClient
-	defer func() {
-		GCSClient = saveGCSClient
-	}()
+	stClient, err := testhelper.NewClient(context.Background(), "newclient,upload")
+	if err != nil {
+		t.Fatalf("testhelper.NewClient() = %v, wanted nil", err)
+	}
 	for i, test := range tests {
 		gcsConf := GCSConfig{
-			Bucket:  test.gcsBucket,
-			DataDir: test.gcsDataDir,
-			BaseID:  test.gcsBaseID,
+			GCSClient: stClient,
+			Bucket:    test.gcsBucket,
+			DataDir:   test.gcsDataDir,
+			BaseID:    test.gcsBaseID,
 		}
 		bundleConf := BundleConfig{
 			Datatype: "foo1",
@@ -122,11 +122,6 @@ func TestNew(t *testing.T) { //nolint:paralleltest
 }
 
 func TestBundleAndUploadCtx(t *testing.T) { //nolint:paralleltest
-	saveGCSClient := GCSClient
-	GCSClient = testhelper.DiskNewClient
-	defer func() {
-		GCSClient = saveGCSClient
-	}()
 	Verbose(testhelper.VLogf)
 
 	// BundleAndUpload() returns when its context is canceled.
@@ -146,11 +141,6 @@ func TestBundleAndUploadCtx(t *testing.T) { //nolint:paralleltest
 }
 
 func TestBundleAndUploadTooBig(t *testing.T) { //nolint:paralleltest
-	saveGCSClient := GCSClient
-	GCSClient = testhelper.DiskNewClient
-	defer func() {
-		GCSClient = saveGCSClient
-	}()
 	Verbose(testhelper.VLogf)
 
 	// Force not enough room in the bundle by setting sizeMax to a
@@ -220,10 +210,15 @@ func setupClients(t *testing.T, sizeMax uint, ageMax time.Duration) (*testhelper
 	}
 
 	// Create a bundler and uploader client.
+	stClient, err := testhelper.NewClient(context.Background(), "newclient,upload")
+	if err != nil {
+		t.Fatalf("testhelper.NewClient() = %v, wanted nil", err)
+	}
 	gcsConf := GCSConfig{
-		Bucket:  "newclient,upload",
-		DataDir: "testdata/autoload/v0",
-		BaseID:  "some-string",
+		GCSClient: stClient,
+		Bucket:    "newclient,upload",
+		DataDir:   "testdata/autoload/v0",
+		BaseID:    "some-string",
 	}
 	bundleConf := BundleConfig{
 		Datatype: "foo1",

--- a/test/README.txt
+++ b/test/README.txt
@@ -24,7 +24,7 @@ $ pwd
 $ mkdir -p cmd/jostler/testdata/spool/jostler/foo1
 $ go build -o . ./cmd/jostler
 $ ./jostler \
-	-no-gcs \
+	-local-disk \
 	-mlab-node-name ndt-mlab1-lga01.mlab-sandbox.measurement-lab.org \
 	-gcs-bucket disk,newclient,download,upload \
 	-data-home-dir $(pwd)/cmd/jostler/testdata/spool \
@@ -36,7 +36,7 @@ $ ./jostler \
 	-missed-age 20s \
 	-missed-interval 15s
 
-Because the -no-gcs flag is specified, jostler will use testhelper's local
+Because the -local-disk flag is specified, jostler will use testhelper's local
 disk storage implementation which mimics downloads from and uploads to
 cloud storage (GCS).  This makes testing and debugging a lot easier.
 


### PR DESCRIPTION
This commit reworks code (without changing its functionality) to use Go interfaces for replacing a local disk storage implementation that mimics downloads from and uploads to GCS for package and e2e testing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/jostler/23)
<!-- Reviewable:end -->
