### PR TITLE
Change GCS object paths

### DIFF
--- a/cmd/jostler/cli.go
+++ b/cmd/jostler/cli.go
@@ -57,7 +57,7 @@ var (
 func initFlags() {
 	// Flags related to GCS.
 	flag.StringVar(&bucket, "gcs-bucket", "", "required - GCS bucket name")
-	flag.StringVar(&gcsHomeDir, "gcs-home-dir", "autoload/v0", "home directory in GCS bucket under which bundles will be uploaded")
+	flag.StringVar(&gcsHomeDir, "gcs-home-dir", "autoload/v1", "home directory in GCS bucket under which bundles will be uploaded")
 	flag.StringVar(&mlabNodeName, "mlab-node-name", "", "required - node name specified directly or via MLAB_NODE_NAME env variable")
 
 	// Flags related to bundles.

--- a/cmd/jostler/main.go
+++ b/cmd/jostler/main.go
@@ -35,9 +35,9 @@
 //  2. Datatype schema files will be read from the local filesystem at:
 //     /var/spool/datatypes/<datatype>.json
 //  3. Table schema files will be uploaded to GCS as:
-//     autoload/v0/tables/<experiment>/<datatype>.table.json
+//     autoload/v1/tables/<experiment>/<datatype>.table.json
 //  4. JSONL files will be uploaded to GCS as:
-//     autoload/v0/<experiment>/<datatype>/<yyyy>/<mm>/<dd>/<timestamp>-<datatype>-<node-name>-<experiment>.jsonl.gz
+//     autoload/v1/<experiment>/<datatype>/date=<yyyy>-<mm>-<dd>/<timestamp>-<datatype>-<node-name>-<experiment>.jsonl.gz
 package main
 
 import (
@@ -128,6 +128,7 @@ func daemonMode() error {
 		mainCancel()
 		return fmt.Errorf("failed to create storage client: %w", err)
 	}
+
 	// Validate table schemas are backward compatible and upload the
 	// ones are a superset of the previous table.
 	for _, datatype := range datatypes {

--- a/cmd/jostler/main_test.go
+++ b/cmd/jostler/main_test.go
@@ -182,7 +182,7 @@ func TestCLI(t *testing.T) { //nolint:funlen,paralleltest
 	}()
 	for i, test := range tests {
 		if test.rmTblSchemaFile {
-			os.RemoveAll("testdata/autoload/v0/tables/jostler/foo1.table.json")
+			os.RemoveAll("testdata/autoload/v1/tables/jostler/foo1.table.json")
 		}
 		var s string
 		if test.wantErrStr == "" {

--- a/internal/jsonlbundle/jsonlbundle.go
+++ b/internal/jsonlbundle/jsonlbundle.go
@@ -55,7 +55,7 @@ func New(bucket, gcsDataDir, gcsBaseID, datatype, dateSubdir string) *JSONLBundl
 		Datatype:   datatype,
 		DateSubdir: dateSubdir,
 		bucket:     bucket,
-		ObjDir:     fmt.Sprintf("%s/%s", gcsDataDir, nowUTC.Format("2006/01/02")), // e.g., ndt/pcap/2022/09/14
+		ObjDir:     fmt.Sprintf("%s/date=%s", gcsDataDir, nowUTC.Format("2006-01-02")), // e.g., ndt/pcap/date=2022-09-14
 		ObjName:    objName + ".jsonl",
 		IdxName:    objName + ".index",
 		FullPaths:  []string{},

--- a/internal/jsonlbundle/jsonlbundle_test.go
+++ b/internal/jsonlbundle/jsonlbundle_test.go
@@ -152,7 +152,7 @@ func newJb(bucket, gcsDataDir, gcsBaseID, datatype, dateSubdir string, timestamp
 		Datatype:   datatype,
 		DateSubdir: dateSubdir,
 		bucket:     bucket,
-		ObjDir:     fmt.Sprintf("%s/%s", gcsDataDir, timestamp.Format("2006/01/02")), // e.g., ndt/pcap/2022/09/14
+		ObjDir:     fmt.Sprintf("%s/date=%s", gcsDataDir, timestamp.Format("2006-01-02")), // e.g., ndt/pcap/date=2022-09-14
 		ObjName:    objName + ".jsonl",
 		IdxName:    objName + ".index",
 		FullPaths:  []string{},

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -33,7 +33,7 @@ type (
 
 var (
 	dtSchemaPathTemplate  = "/var/spool/datatypes/<datatype>.json"
-	tblSchemaPathTemplate = "autoload/v0/tables/<experiment>/<datatype>.table.json"
+	tblSchemaPathTemplate = "autoload/v1/tables/<experiment>/<datatype>.table.json"
 
 	ErrStorageClient  = errors.New("failed to create storage client")
 	ErrReadSchema     = errors.New("failed to read schema file")

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -72,7 +72,7 @@ func TestValidateAndUpload(t *testing.T) { //nolint:paralleltest,funlen
 	}{
 		{
 			name:            "non-existent datatype schema file, should not upload",
-			tblSchemaFile:   "autoload/v0/tables/jostler/foo1.table.json",
+			tblSchemaFile:   "autoload/v1/tables/jostler/foo1.table.json",
 			rmTblSchemaFile: false,
 			bucket:          "newclient",
 			experiment:      testExperiment,
@@ -82,7 +82,7 @@ func TestValidateAndUpload(t *testing.T) { //nolint:paralleltest,funlen
 		},
 		{
 			name:            "invalid datatype schema file, should not upload",
-			tblSchemaFile:   "autoload/v0/tables/jostler/foo1.table.json",
+			tblSchemaFile:   "autoload/v1/tables/jostler/foo1.table.json",
 			rmTblSchemaFile: false,
 			bucket:          "newclient",
 			experiment:      testExperiment,
@@ -92,7 +92,7 @@ func TestValidateAndUpload(t *testing.T) { //nolint:paralleltest,funlen
 		},
 		{
 			name:            "force storage client creation failure",
-			tblSchemaFile:   "autoload/v0/tables/jostler/foo1.table.json",
+			tblSchemaFile:   "autoload/v1/tables/jostler/foo1.table.json",
 			rmTblSchemaFile: false,
 			bucket:          "failnewclient",
 			experiment:      testExperiment,
@@ -102,7 +102,7 @@ func TestValidateAndUpload(t *testing.T) { //nolint:paralleltest,funlen
 		},
 		{
 			name:            "scenario 1 - old doesn't exist, should upload, but force upload failure",
-			tblSchemaFile:   "autoload/v0/tables/jostler/foo1.table.json",
+			tblSchemaFile:   "autoload/v1/tables/jostler/foo1.table.json",
 			rmTblSchemaFile: true,
 			bucket:          "newclient,download,failupload",
 			experiment:      testExperiment,
@@ -112,7 +112,7 @@ func TestValidateAndUpload(t *testing.T) { //nolint:paralleltest,funlen
 		},
 		{
 			name:            "scenario 1 - old doesn't exist, should upload",
-			tblSchemaFile:   "autoload/v0/tables/jostler/foo1.table.json",
+			tblSchemaFile:   "autoload/v1/tables/jostler/foo1.table.json",
 			rmTblSchemaFile: true,
 			bucket:          "newclient,download,upload",
 			experiment:      testExperiment,
@@ -122,7 +122,7 @@ func TestValidateAndUpload(t *testing.T) { //nolint:paralleltest,funlen
 		},
 		{
 			name:            "scenario 2 - old exists, new matches, but force download failure",
-			tblSchemaFile:   "autoload/v0/tables/jostler/foo1.table.json",
+			tblSchemaFile:   "autoload/v1/tables/jostler/foo1.table.json",
 			rmTblSchemaFile: false,
 			bucket:          "newclient,faildownload",
 			experiment:      testExperiment,
@@ -132,7 +132,7 @@ func TestValidateAndUpload(t *testing.T) { //nolint:paralleltest,funlen
 		},
 		{
 			name:            "scenario 2 - old exists, new matches, should not upload",
-			tblSchemaFile:   "autoload/v0/tables/jostler/foo1.table.json",
+			tblSchemaFile:   "autoload/v1/tables/jostler/foo1.table.json",
 			rmTblSchemaFile: false,
 			bucket:          "newclient,download",
 			experiment:      testExperiment,
@@ -142,7 +142,7 @@ func TestValidateAndUpload(t *testing.T) { //nolint:paralleltest,funlen
 		},
 		{
 			name:            "scenario 3 - old exists, new is a superset, should upload",
-			tblSchemaFile:   "autoload/v0/tables/jostler/foo1.table.json",
+			tblSchemaFile:   "autoload/v1/tables/jostler/foo1.table.json",
 			rmTblSchemaFile: false,
 			bucket:          "newclient,download,upload",
 			experiment:      testExperiment,
@@ -152,7 +152,7 @@ func TestValidateAndUpload(t *testing.T) { //nolint:paralleltest,funlen
 		},
 		{
 			name:            "scenario 4 - old exists, new is incompatible due to missing field mismatch, should not upload",
-			tblSchemaFile:   "autoload/v0/tables/jostler/foo1.table.json",
+			tblSchemaFile:   "autoload/v1/tables/jostler/foo1.table.json",
 			rmTblSchemaFile: false,
 			bucket:          "newclient,download",
 			experiment:      testExperiment,
@@ -162,7 +162,7 @@ func TestValidateAndUpload(t *testing.T) { //nolint:paralleltest,funlen
 		},
 		{
 			name:            "scenario 4 - old exists, new is incompatible due to field types, should not upload",
-			tblSchemaFile:   "autoload/v0/tables/jostler/foo1.table.json",
+			tblSchemaFile:   "autoload/v1/tables/jostler/foo1.table.json",
 			rmTblSchemaFile: false,
 			bucket:          "newclient,download",
 			experiment:      testExperiment,

--- a/internal/testhelper/testhelper.go
+++ b/internal/testhelper/testhelper.go
@@ -101,7 +101,7 @@ func (d *StorageClient) Download(ctx context.Context, objPath string) ([]byte, e
 
 // Upload mimics uploading to GCS.
 func (d *StorageClient) Upload(ctx context.Context, objPath string, contents []byte) error {
-	fmt.Printf("StorageClient.upload(): d.bucket=%v objPath=%v len(contents)=%v\n", d.bucket, objPath, len(contents)) //nolint:forbidigo
+	fmt.Printf("StorageClient.Upload(): d.bucket=%v objPath=%v len(contents)=%v\n", d.bucket, objPath, len(contents)) //nolint:forbidigo
 	if !strings.HasPrefix(objPath, "testdata") {
 		objPath = filepath.Join("testdata", objPath)
 	}
@@ -111,7 +111,7 @@ func (d *StorageClient) Upload(ctx context.Context, objPath string, contents []b
 	if strings.Contains(d.bucket, "failupload") {
 		return schema.ErrUpload
 	}
-	idx := strings.LastIndex(objPath, "/") // autoload/v0/tables/<experiment>/<datatype>.table.json
+	idx := strings.LastIndex(objPath, "/") // autoload/v1/tables/<experiment>/<datatype>.table.json
 	if idx == -1 {
 		panic("Upload(): objPath")
 	}

--- a/internal/uploadbundle/uploadbundle.go
+++ b/internal/uploadbundle/uploadbundle.go
@@ -13,7 +13,7 @@
 //
 // Bundle objects uploaded to GCS follow this naming convention:
 //
-//	<BundleConfig.DataDir>/<yyyy>/<mm>/<dd>/<timestamp>-<BaseID>.jsonl.gz
+//	<BundleConfig.DataDir>/date=<yyyy>-<mm>-<dd>/<timestamp>-<BaseID>.jsonl.gz
 package uploadbundle
 
 import (
@@ -58,8 +58,8 @@ type Uploader interface {
 // GCSConfig defines GCS configuration options.
 //
 // GCS object names of JSONL bundles have the following format:
-// autoload/v0/<experiment>/<datatype>/<yyyy>/<mm>/<dd>/<timestamp>-<datatype>-<node-name>-<experiment>.jsonl.gz
-// |------------DataDir--------------|                              |-------------BaseID--------------|
+// autoload/v1/<experiment>/<datatype>/date=<yyyy>-<mm>-<dd>/<timestamp>-<datatype>-<node-name>-<experiment>.jsonl.gz
+// |------------DataDir--------------|                                   |-------------BaseID--------------|
 //
 // Note that while slashes ("/") in GCS object names create the illusion
 // of a directory hierarchy, GCS has a flat namesapce.

--- a/internal/uploadbundle/uploadbundle_test.go
+++ b/internal/uploadbundle/uploadbundle_test.go
@@ -217,7 +217,7 @@ func setupClients(t *testing.T, sizeMax uint, ageMax time.Duration) (*testhelper
 	gcsConf := GCSConfig{
 		GCSClient: stClient,
 		Bucket:    "newclient,upload",
-		DataDir:   "testdata/autoload/v0",
+		DataDir:   "testdata/autoload/v1",
 		BaseID:    "some-string",
 	}
 	bundleConf := BundleConfig{

--- a/test/README.txt
+++ b/test/README.txt
@@ -26,7 +26,7 @@ $ go build -o . ./cmd/jostler
 $ ./jostler \
 	-local-disk \
 	-mlab-node-name ndt-mlab1-lga01.mlab-sandbox.measurement-lab.org \
-	-gcs-bucket disk,newclient,download,upload \
+	-gcs-bucket newclient,download,upload \
 	-data-home-dir $(pwd)/cmd/jostler/testdata/spool \
 	-experiment jostler \
 	-datatype foo1 \
@@ -49,9 +49,9 @@ $ while :; do tree testdata cmd/jostler/testdata/spool; sleep 1; done
 You will see that data files are created by test/data.go in the
 subdirectories of:
 
-	.../jostler/cmd/jostler/testdata/spool/jostler/foo1/2022/11
+	.../jostler/cmd/jostler/testdata/spool/jostler/foo1/<yyyy>/<mm>/
 
 and are deleted by jostler after they are bundled and "uploaded" to the
 subdirectories of:
 
-	.../jostler/testdata/autoload/v0/jostler/foo1/2002/11
+	.../jostler/testdata/autoload/v1/jostler/foo1/date=<yyyy>-<mm>-<dd>


### PR DESCRIPTION
This commit changes autoload/v0 to autoload/v1 for all GCS object paths.  For JSONL archives, it also changes `.../<yyyy>/<mm>/<dd>/... `to `.../date=<yyyy>-<mm>-<dd>/...` to support partitioned tables in BigQuery.

The changes were tested locally with `go test -race ./...` and also with e2e testing scripts in the `test` subdirectory.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/jostler/24)
<!-- Reviewable:end -->
