### PR TITLE
Remove Date from M-Lab's standard columns

### DIFF
--- a/api/standard_columns.go
+++ b/api/standard_columns.go
@@ -8,7 +8,6 @@ package api
 // type should be declared as "any" but bigquery.InferSchema() does not
 // support "any" (or "interface{}").
 type StandardColumnsV0 struct {
-	Date     string     `bigquery:"date"`     // yyyy-mm-dd pathname component of measurement data
 	Archiver ArchiverV0 `bigquery:"archiver"` // archiver details
 	Raw      string     `bigquery:"raw"`      // measurement data (file contents) in JSON format
 }

--- a/internal/jsonlbundle/jsonlbundle.go
+++ b/internal/jsonlbundle/jsonlbundle.go
@@ -89,7 +89,6 @@ func (jb *JSONLBundle) AddFile(fullPath, version, gitCommit string) error {
 		return err
 	}
 	stdCols := api.StandardColumnsV0{
-		Date: jb.DateSubdir,
 		Archiver: api.ArchiverV0{
 			Version:    version,
 			GitCommit:  gitCommit,


### PR DESCRIPTION
Since the GCS object pathnames of JSONL bundles include `date=<yyyy>-<mm>-<dd>`, BigQuery will automatically provide a `Date` column, obviating the need for defining it in M-Lab's standard columns.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/jostler/25)
<!-- Reviewable:end -->
