### PR TITLE
Prepare test code for index1 datatype

### DIFF
--- a/cmd/jostler/cli.go
+++ b/cmd/jostler/cli.go
@@ -29,7 +29,7 @@ var (
 	bundleAgeMax  time.Duration
 
 	// Flags related to where to watch for data (inotify events).
-	dataHomeDir    string
+	localDataDir   string
 	extensions     flagx.StringArray
 	experiment     string
 	datatypes      flagx.StringArray
@@ -66,7 +66,7 @@ func initFlags() {
 	flag.DurationVar(&bundleAgeMax, "bundle-age-max", 1*time.Hour, "maximum bundle age before it is uploaded")
 
 	// Flags related to where to watch for data (inotify events).
-	flag.StringVar(&dataHomeDir, "data-home-dir", "/var/spool", "directory pathname under which measurement data is created")
+	flag.StringVar(&localDataDir, "local-data-dir", "/var/spool", "directory pathname under which measurement data is created")
 	extensions = flagx.StringArray{".json"}
 	flag.StringVar(&experiment, "experiment", "", "required - name of the experiment (e.g., ndt)")
 	datatypes = flagx.StringArray{}

--- a/cmd/jostler/cli.go
+++ b/cmd/jostler/cli.go
@@ -20,7 +20,7 @@ import (
 var (
 	// Flags related to GCS.
 	bucket       string
-	gcsHomeDir   string
+	gcsDataDir   string
 	mlabNodeName string
 
 	// Flags related to bundles.
@@ -39,7 +39,7 @@ var (
 	// Flags related to program's execution.
 	local        bool
 	verbose      bool
-	localDisk    bool
+	gcsLocalDisk bool
 	testInterval time.Duration
 
 	// Errors related to command line parsing and validation.
@@ -57,7 +57,7 @@ var (
 func initFlags() {
 	// Flags related to GCS.
 	flag.StringVar(&bucket, "gcs-bucket", "", "required - GCS bucket name")
-	flag.StringVar(&gcsHomeDir, "gcs-home-dir", "autoload/v1", "home directory in GCS bucket under which bundles will be uploaded")
+	flag.StringVar(&gcsDataDir, "gcs-data-dir", "autoload/v1", "home directory in GCS bucket under which bundles will be uploaded")
 	flag.StringVar(&mlabNodeName, "mlab-node-name", "", "required - node name specified directly or via MLAB_NODE_NAME env variable")
 
 	// Flags related to bundles.
@@ -76,7 +76,7 @@ func initFlags() {
 	// Flags related to program's execution.
 	flag.BoolVar(&local, "local", false, "run locally and create schema files for each datatype")
 	flag.BoolVar(&verbose, "verbose", false, "enable verbose mode")
-	flag.BoolVar(&localDisk, "local-disk", false, "use local disk storage instead of cloud storage (for test purposes only)")
+	flag.BoolVar(&gcsLocalDisk, "gcs-local-disk", false, "use local disk storage instead of cloud storage (for test purposes only)")
 	flag.DurationVar(&testInterval, "test-interval", 0, "time interval to stop running (for test purposes only)")
 
 	flag.Var(&dtSchemaFiles, "datatype-schema-file", "schema for each datatype in the format <datatype>:<pathname>")

--- a/cmd/jostler/main.go
+++ b/cmd/jostler/main.go
@@ -79,7 +79,7 @@ func main() {
 		fatal(err)
 	}
 	schema.LocalDataDir = localDataDir
-	schema.GCSHomeDir = gcsHomeDir
+	schema.GCSDataDir = gcsDataDir
 
 	if local {
 		if err := localMode(); err != nil {
@@ -117,11 +117,11 @@ func localMode() error {
 func daemonMode() error {
 	mainCtx, mainCancel := context.WithCancel(context.Background())
 	// Create a storage client.
-	// The localDisk flag is meant for e2e testing where we want to read
+	// The gcsLocalDisk flag is meant for e2e testing where we want to read
 	// from and write to the local disk storage instead of cloud storage.
 	var stClient schema.DownloaderUploader
 	var err error
-	if localDisk {
+	if gcsLocalDisk {
 		stClient, err = testhelper.NewClient(mainCtx, bucket)
 	} else {
 		stClient, err = gcs.NewClient(mainCtx, bucket)
@@ -203,10 +203,10 @@ func startUploader(mainCtx context.Context, mainCancel context.CancelFunc, statu
 	}
 
 	// Create a storage client.
-	// The localDisk flag is meant for e2e testing where we want to read
+	// The gcsLocalDisk flag is meant for e2e testing where we want to read
 	// from and write to the local disk storage instead of cloud storage.
 	var stClient uploadbundle.Uploader
-	if localDisk {
+	if gcsLocalDisk {
 		stClient, err = testhelper.NewClient(mainCtx, bucket)
 	} else {
 		stClient, err = gcs.NewClient(mainCtx, bucket)
@@ -217,7 +217,7 @@ func startUploader(mainCtx context.Context, mainCancel context.CancelFunc, statu
 	gcsConf := uploadbundle.GCSConfig{
 		GCSClient: stClient,
 		Bucket:    bucket,
-		DataDir:   filepath.Join(gcsHomeDir, experiment, datatype),
+		DataDir:   filepath.Join(gcsDataDir, experiment, datatype),
 		BaseID:    fmt.Sprintf("%s-%s-%s-%s", datatype, nameParts.Machine, nameParts.Site, experiment),
 	}
 	bundleConf := uploadbundle.BundleConfig{

--- a/cmd/jostler/main.go
+++ b/cmd/jostler/main.go
@@ -78,6 +78,8 @@ func main() {
 	if err := parseAndValidateCLI(); err != nil {
 		fatal(err)
 	}
+	schema.LocalDataDir = localDataDir
+	schema.GCSHomeDir = gcsHomeDir
 
 	if local {
 		if err := localMode(); err != nil {
@@ -179,7 +181,7 @@ func daemonMode() error {
 // specified directory and notifies its client of new (and potentially
 // missed) files.
 func startWatcher(mainCtx context.Context, mainCancel context.CancelFunc, status chan<- error, datatype string, watchEvents []notify.Event) (*watchdir.WatchDir, error) {
-	watchDir := filepath.Join(dataHomeDir, experiment, datatype)
+	watchDir := filepath.Join(localDataDir, experiment, datatype)
 	wdClient, err := watchdir.New(watchDir, extensions, watchEvents, missedAge, missedInterval)
 	if err != nil {
 		return nil, fmt.Errorf("failed to instantiate watcher: %w", err)
@@ -222,7 +224,7 @@ func startUploader(mainCtx context.Context, mainCancel context.CancelFunc, statu
 		Version:   version,
 		GitCommit: gitCommit,
 		Datatype:  datatype,
-		DataDir:   filepath.Join(dataHomeDir, experiment, datatype),
+		DataDir:   filepath.Join(localDataDir, experiment, datatype),
 		SizeMax:   bundleSizeMax,
 		AgeMax:    bundleAgeMax,
 	}

--- a/cmd/jostler/main_test.go
+++ b/cmd/jostler/main_test.go
@@ -14,11 +14,11 @@ import (
 )
 
 const (
-	testNode        = "mlab1-lga01.mlab-sandbox.measurement-lab.org"
-	testDataHomeDir = "testdata"    // typically /var/spool
-	testBucket      = "disk-bucket" // typically pusher-mlab-sandbox
-	testExperiment  = "jostler"
-	testDatatype    = "foo1"
+	testNode         = "mlab1-lga01.mlab-sandbox.measurement-lab.org"
+	testLocalDataDir = "testdata"    // typically /var/spool
+	testBucket       = "disk-bucket" // typically pusher-mlab-sandbox
+	testExperiment   = "jostler"
+	testDatatype     = "foo1"
 )
 
 // TestCLI tests non-interactive CLI invocations.
@@ -136,7 +136,7 @@ func TestCLI(t *testing.T) { //nolint:funlen,paralleltest
 			[]string{
 				"-gcs-bucket", "newclient,download,upload",
 				"-mlab-node-name", testNode,
-				"-data-home-dir", testDataHomeDir,
+				"-local-data-dir", testLocalDataDir,
 				"-experiment", testExperiment,
 				"-datatype", "foo1",
 				"-datatype-schema-file", "foo1:testdata/datatypes/foo1-valid.json",
@@ -147,7 +147,7 @@ func TestCLI(t *testing.T) { //nolint:funlen,paralleltest
 			[]string{
 				"-gcs-bucket", "newclient,download",
 				"-mlab-node-name", testNode,
-				"-data-home-dir", testDataHomeDir,
+				"-local-data-dir", testLocalDataDir,
 				"-experiment", testExperiment,
 				"-datatype", "foo1",
 				"-datatype-schema-file", "foo1:testdata/datatypes/foo1-valid.json",
@@ -158,7 +158,7 @@ func TestCLI(t *testing.T) { //nolint:funlen,paralleltest
 			[]string{
 				"-gcs-bucket", "newclient,download,upload",
 				"-mlab-node-name", testNode,
-				"-data-home-dir", testDataHomeDir,
+				"-local-data-dir", testLocalDataDir,
 				"-experiment", testExperiment,
 				"-datatype", "foo1",
 				"-datatype-schema-file", "foo1:testdata/datatypes/foo1-valid-superset.json",
@@ -169,7 +169,7 @@ func TestCLI(t *testing.T) { //nolint:funlen,paralleltest
 			[]string{
 				"-gcs-bucket", "newclient,download",
 				"-mlab-node-name", testNode,
-				"-data-home-dir", testDataHomeDir,
+				"-local-data-dir", testLocalDataDir,
 				"-experiment", testExperiment,
 				"-datatype", "foo1",
 				"-datatype-schema-file", "foo1:testdata/datatypes/foo1-valid.json",
@@ -194,7 +194,7 @@ func TestCLI(t *testing.T) { //nolint:funlen,paralleltest
 		args := test.args
 		// Use a local disk storage implementation that mimics downloads
 		// from and uploads to GCS.
-		args = append(args, "-local-disk")
+		args = append(args, []string{"-local-disk", "-gcs-home-dir", "testdata/autoload/v1"}...)
 		if testing.Verbose() {
 			args = append(args, "-verbose")
 		}

--- a/cmd/jostler/main_test.go
+++ b/cmd/jostler/main_test.go
@@ -194,7 +194,7 @@ func TestCLI(t *testing.T) { //nolint:funlen,paralleltest
 		args := test.args
 		// Use a local disk storage implementation that mimics downloads
 		// from and uploads to GCS.
-		args = append(args, []string{"-local-disk", "-gcs-home-dir", "testdata/autoload/v1"}...)
+		args = append(args, []string{"-gcs-local-disk", "-gcs-data-dir", "testdata/autoload/v1"}...)
 		if testing.Verbose() {
 			args = append(args, "-verbose")
 		}

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -33,7 +33,7 @@ type (
 
 var (
 	LocalDataDir          = "/var/spool"
-	GCSHomeDir            = "autoload/v1"
+	GCSDataDir            = "autoload/v1"
 	dtSchemaPathTemplate  = "/datatypes/<datatype>.json"
 	tblSchemaPathTemplate = "/tables/<experiment>/<datatype>.table.json"
 
@@ -192,7 +192,7 @@ func diffTableSchemas(gcsClient DownloaderUploader, bucket, experiment, datatype
 // experiment and datatype.
 func tblSchemaPath(experiment, datatype string) string {
 	objPath := strings.Replace(tblSchemaPathTemplate, "<experiment>", experiment, 1)
-	return GCSHomeDir + strings.Replace(objPath, "<datatype>", datatype, 1)
+	return GCSDataDir + strings.Replace(objPath, "<datatype>", datatype, 1)
 }
 
 // uploadTableSchema creates a table schema for the given datatype schema

--- a/internal/testhelper/testhelper.go
+++ b/internal/testhelper/testhelper.go
@@ -80,9 +80,6 @@ func NewClient(ctx context.Context, bucket string) (*StorageClient, error) {
 // Download mimics downloading from GCS.
 func (d *StorageClient) Download(ctx context.Context, objPath string) ([]byte, error) {
 	fmt.Printf("StorageClient.Download(): d.bucket=%v objPath=%v\n", d.bucket, objPath) //nolint:forbidigo
-	if !strings.HasPrefix(objPath, "testdata") {
-		objPath = filepath.Join("testdata", objPath)
-	}
 	if !strings.Contains(d.bucket, "download") {
 		panic("unexpected call to Download()")
 	}
@@ -102,9 +99,6 @@ func (d *StorageClient) Download(ctx context.Context, objPath string) ([]byte, e
 // Upload mimics uploading to GCS.
 func (d *StorageClient) Upload(ctx context.Context, objPath string, contents []byte) error {
 	fmt.Printf("StorageClient.Upload(): d.bucket=%v objPath=%v len(contents)=%v\n", d.bucket, objPath, len(contents)) //nolint:forbidigo
-	if !strings.HasPrefix(objPath, "testdata") {
-		objPath = filepath.Join("testdata", objPath)
-	}
 	if !strings.Contains(d.bucket, "upload") {
 		panic("unexpected call to Upload()")
 	}

--- a/test/README.txt
+++ b/test/README.txt
@@ -1,4 +1,4 @@
-There are two files in this test directory to help with integration
+There are three files in this test directory to help with integration
 and e2e testing.
 
 1. schema.sh is a bash script that can be used for testing table schema
@@ -8,50 +8,38 @@ and e2e testing.
 2. data.go is a very simple Go program that mimics a measurement service
    by creating measurement data files for jostler to bundle and upload.
 
-data.go can be started in one terminal and jostler can be started in
-another terminal as follows:
+3. e2e.sh is a bash script to invoke jostler with the right parameters
+   for e2e testing.
+
+The easiest way to do e2e testing is to run jostler in one terminal and
+run data.go in another terminal as shown below:
+
 
 [Term A]
-$ pwd
-.../jostler
-$ cd test
-$ go run data.go -sleep 1s
+$ cd /path/to/your/jostler/directory
+$ EXPERIMENT=experiment DATATYPE=datatype1 ./test/e2e.sh
+
+Because e2e.sh invokes jostler with the -local-disk flag, jostler will
+use testhelper's local disk storage implementation which mimics downloads
+from and uploads to cloud storage (GCS).  This makes testing and debugging
+a lot easier.
 
 
 [Term B]
-$ pwd
-.../jostler
-$ mkdir -p cmd/jostler/testdata/spool/jostler/foo1
-$ go build -o . ./cmd/jostler
-$ ./jostler \
-	-local-disk \
-	-mlab-node-name ndt-mlab1-lga01.mlab-sandbox.measurement-lab.org \
-	-gcs-bucket newclient,download,upload \
-	-data-home-dir $(pwd)/cmd/jostler/testdata/spool \
-	-experiment jostler \
-	-datatype foo1 \
-	-datatype-schema-file foo1:cmd/jostler/testdata/datatypes/foo1-valid.json \
-	-bundle-size-max 1024 \
-	-bundle-age-max 10s \
-	-missed-age 20s \
-	-missed-interval 15s
-
-Because the -local-disk flag is specified, jostler will use testhelper's local
-disk storage implementation which mimics downloads from and uploads to
-cloud storage (GCS).  This makes testing and debugging a lot easier.
+$ cd /path/to/your/jostler/directory/test
+$ EXPERIMENT=experiment DATATYPE=datatype1 go run data.go -sleep 1s -verbose
 
 
 [Term C]
-$ pwd
-.../jostler
-$ while :; do tree testdata cmd/jostler/testdata/spool; sleep 1; done
+$ cd /path/to/your/jostler/directory
+$ while :; do tree e2e; sleep 3; done
 
 You will see that data files are created by test/data.go in the
 subdirectories of:
 
-	.../jostler/cmd/jostler/testdata/spool/jostler/foo1/<yyyy>/<mm>/
+	e2e/local/var/spool/$EXPERIMENT/$DATATYPE/<yyyy>/<mm>/<dd>
 
-and are deleted by jostler after they are bundled and "uploaded" to the
-subdirectories of:
+and are deleted by jostler after bundles and their indices are "uploaded" to the
+following directory:
 
-	.../jostler/testdata/autoload/v1/jostler/foo1/date=<yyyy>-<mm>-<dd>
+	e2e/gcs/autoload/v1/$EXPERIMENT/$DATAYPE/date=<yyyy>-<mm>-<dd>

--- a/test/README.txt
+++ b/test/README.txt
@@ -19,7 +19,7 @@ run data.go in another terminal as shown below:
 $ cd /path/to/your/jostler/directory
 $ EXPERIMENT=experiment DATATYPE=datatype1 ./test/e2e.sh
 
-Because e2e.sh invokes jostler with the -local-disk flag, jostler will
+Because e2e.sh invokes jostler with the -gcs-local-disk flag, jostler will
 use testhelper's local disk storage implementation which mimics downloads
 from and uploads to cloud storage (GCS).  This makes testing and debugging
 a lot easier.

--- a/test/data.go
+++ b/test/data.go
@@ -9,18 +9,29 @@ import (
 )
 
 var (
-	dataHomeDir = flag.String("data-home-dir", "../cmd/jostler/testdata/spool", "directory pathname under which measurement data is created")
-	experiment  = flag.String("experiment", "jostler", "name of the experiment")
-	datatype    = flag.String("datatype", "foo1", "name of the datatype")
-	nDays       = flag.Int("days", 7, "number of date subdirectories")
-	sleep       = flag.Duration("sleep", 100*time.Millisecond, "sleep time in milliseconds between file creations")
-	verbose     = flag.Bool("verbose", false, "enable verbose mode")
+	localDataDir = flag.String("local-data-dir", "../e2e/local/var/spool", "local pathname under which measurement data is created")
+	experiment   = flag.String("experiment", "", "name of the experiment")
+	datatype     = flag.String("datatype", "", "name of the datatype")
+	nDays        = flag.Int("days", 7, "number of date subdirectories")
+	sleep        = flag.Duration("sleep", 100*time.Millisecond, "sleep time in milliseconds between file creations")
+	verbose      = flag.Bool("verbose", false, "enable verbose mode")
 
 	dirs = []string{}
 )
 
 func main() {
 	flag.Parse()
+	if *experiment == "" {
+		*experiment = os.Getenv("EXPERIMENT")
+	}
+	if *datatype == "" {
+		*datatype = os.Getenv("DATATYPE")
+	}
+
+	if *experiment == "" || *datatype == "" {
+		fmt.Println("must specify both experiment and datatype") //nolint
+		os.Exit(1)
+	}
 	createDateSubdirs()
 	createDataFiles()
 }
@@ -28,7 +39,7 @@ func main() {
 func createDateSubdirs() {
 	now := time.Now()
 	for i := 0; i < *nDays; i++ {
-		dir := fmt.Sprintf("%s/%s/%s/%s", *dataHomeDir, *experiment, *datatype, now.AddDate(0, 0, -i).Format("2006/01/02"))
+		dir := fmt.Sprintf("%s/%s/%s/%s", *localDataDir, *experiment, *datatype, now.AddDate(0, 0, -i).Format("2006/01/02"))
 		if *verbose {
 			fmt.Printf("creating %s\n", dir) //nolint
 		}

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# This is a helper script for e2e testing by performing the following:
+#
+#   1. Building jostler.
+#   2. Creating the required directories and files.
+#   3. Invoking jostler.
+#
+# See README.txt in this directory for additional details.
+
 set -eux
 
 if [[ -z "$EXPERIMENT" || -z "$DATATYPE" ]]; then
@@ -19,10 +27,10 @@ cp cmd/jostler/testdata/datatypes/foo1-valid.json $E2E_DATATYPE_SCHEMA_DIR/$DATA
 git clean -ndx
 
 ./jostler \
-	-local-disk \
+	-gcs-local-disk \
 	-mlab-node-name $EXPERIMENT-mlab1-lga01.mlab-sandbox.measurement-lab.org \
 	-gcs-bucket newclient,download,upload \
-	-gcs-home-dir e2e/gcs/autoload/v1 \
+	-gcs-data-dir e2e/gcs/autoload/v1 \
 	-local-data-dir $E2E_SPOOL_DIR \
 	-experiment $EXPERIMENT \
 	-datatype $DATATYPE \

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -eux
+
+if [[ -z "$EXPERIMENT" || -z "$DATATYPE" ]]; then
+	echo both EXPERIMENT and DATATYPE must be set
+	exit 1
+fi
+
+go build -o . ./cmd/jostler
+
+readonly E2E_SPOOL_DIR=$(pwd)/e2e/local/var/spool
+readonly E2E_DATATYPE_SCHEMA_DIR=$E2E_SPOOL_DIR/datatypes
+readonly LOCAL_DATA_DIR=$E2E_SPOOL_DIR/$EXPERIMENT/$DATATYPE
+
+mkdir -p $E2E_DATATYPE_SCHEMA_DIR $LOCAL_DATA_DIR
+cp cmd/jostler/testdata/datatypes/foo1-valid.json $E2E_DATATYPE_SCHEMA_DIR/$DATATYPE.json
+
+git clean -ndx
+
+./jostler \
+	-local-disk \
+	-mlab-node-name $EXPERIMENT-mlab1-lga01.mlab-sandbox.measurement-lab.org \
+	-gcs-bucket newclient,download,upload \
+	-gcs-home-dir e2e/gcs/autoload/v1 \
+	-local-data-dir $E2E_SPOOL_DIR \
+	-experiment $EXPERIMENT \
+	-datatype $DATATYPE \
+	-datatype-schema-file $DATATYPE:$E2E_DATATYPE_SCHEMA_DIR/$DATATYPE.json \
+	-bundle-size-max 1024 \
+	-bundle-age-max 10s \
+	-missed-age 20s \
+	-missed-interval 15s \
+	-verbose


### PR DESCRIPTION
The changes in this commit are mostly for improving e2e testing in preparation for treating bundle index files as `index1` datatype.

There are no changes to the code logic of jostler in this commit.

The changes were tested locally with `go test -race ./...` and `test/e2e.sh`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/jostler/27)
<!-- Reviewable:end -->
