### PR TITLE
Make index bundles look like datatype index1

### DIFF
--- a/api/index.go
+++ b/api/index.go
@@ -1,0 +1,14 @@
+package api
+
+// IndexV1 defines individual entries in the index bundle that describes a
+// data bundle.  The index bundle is uploaded to GCS as datatype of index1
+// so the autoload agent in the pipeline does not have to distinguish
+// between measurement data bundles and index bundles.  In other words,
+// as far as the pipeline is concerned, index1 is just another datatype.
+// Index bundles have the same name as the bundle they describe but their
+// extension is ".index".
+type IndexV1 struct {
+	Filename  string // full pathname to the measurement data file
+	Size      int    // size of the measurement data file
+	TimeAdded string // when measurement data file was added to data bundle
+}

--- a/api/index.go
+++ b/api/index.go
@@ -1,12 +1,12 @@
 package api
 
 // IndexV1 defines individual entries in the index bundle that describes a
-// data bundle.  The index bundle is uploaded to GCS as datatype of index1
-// so the autoload agent in the pipeline does not have to distinguish
-// between measurement data bundles and index bundles.  In other words,
-// as far as the pipeline is concerned, index1 is just another datatype.
-// Index bundles have the same name as the bundle they describe but their
-// extension is ".index".
+// data bundle.
+//
+// The index bundle is uploaded to GCS as datatype of index1 so the autoload
+// agent in the pipeline does not have to distinguish between measurement
+// data bundles and index bundles.  In other words, as far as the pipeline
+// is concerned, index1 is just another datatype.
 type IndexV1 struct {
 	Filename  string // full pathname to the measurement data file
 	Size      int    // size of the measurement data file

--- a/cmd/jostler/main.go
+++ b/cmd/jostler/main.go
@@ -218,13 +218,14 @@ func startUploader(mainCtx context.Context, mainCancel context.CancelFunc, statu
 		GCSClient: stClient,
 		Bucket:    bucket,
 		DataDir:   filepath.Join(gcsDataDir, experiment, datatype),
+		IndexDir:  filepath.Join(gcsDataDir, experiment, "index1"),
 		BaseID:    fmt.Sprintf("%s-%s-%s-%s", datatype, nameParts.Machine, nameParts.Site, experiment),
 	}
 	bundleConf := uploadbundle.BundleConfig{
 		Version:   version,
 		GitCommit: gitCommit,
 		Datatype:  datatype,
-		DataDir:   filepath.Join(localDataDir, experiment, datatype),
+		SpoolDir:  filepath.Join(localDataDir, experiment, datatype),
 		SizeMax:   bundleSizeMax,
 		AgeMax:    bundleAgeMax,
 	}

--- a/internal/jsonlbundle/jsonlbundle.go
+++ b/internal/jsonlbundle/jsonlbundle.go
@@ -13,27 +13,32 @@ import (
 	"github.com/m-lab/jostler/api"
 )
 
-// JSONLBundle defines a collection of JSON file contents bundled together
-// in JSONL format for archiving.
+// JSONLBundle defines a collection of JSON file contents (i.e.,
+// measurement data) bundled together in JSONL format for archiving.
+// There is an index bundle associated with each measurement data bundle.
+// See api/index.go for details about index bundles.
 type JSONLBundle struct {
-	Lines      []string
-	Timestamp  string   // bundle's in-memory creation time that serves as its identifier
-	Datatype   string   // bundle's datatype
-	DateSubdir string   // date subdirectory of files in this bundle (yyyy/mm/dd)
-	bucket     string   // GCS bucket
-	ObjDir     string   // GCS directory to upload this bundle to
-	ObjName    string   // GCS object name of this bundle
-	IdxName    string   // name of the index file for this bundle
-	FullPaths  []string // pathnames of individual JSON files
-	BadFiles   []string // pathnames of files that could not be read or were not proper JSON
-	Size       uint     // size of this bundle
+	Lines      []string      // contents of data files in the bundle
+	BadFiles   []string      // pathnames of data files that could not be read or were not proper JSON
+	Index      []api.IndexV1 // pathnames of data files in the index
+	Timestamp  string        // bundle's in-memory creation time that serves as its identifier
+	Datatype   string        // bundle's datatype
+	DateSubdir string        // date subdirectory of files in this bundle (yyyy/mm/dd)
+	bucket     string        // GCS bucket
+	BundleDir  string        // GCS directory to upload this bundle to
+	BundleName string        // GCS object name of this bundle
+	IndexDir   string        // GCS directory to upload this bundle's index to
+	IndexName  string        // GCS object name of this bundle's index
+	Size       uint          // size of this bundle
 }
 
 var (
-	ErrReadFile    = errors.New("failed to read file")
-	ErrEmptyFile   = errors.New("empty file")
-	ErrInvalidJSON = errors.New("failed to validate JSON")
-	ErrNotOneLine  = errors.New("is not one line")
+	ErrReadFile       = errors.New("failed to read file")
+	ErrEmptyFile      = errors.New("empty file")
+	ErrInvalidJSON    = errors.New("failed to validate JSON")
+	ErrNotOneLine     = errors.New("is not one line")
+	ErrMarshalStdCols = errors.New("failed to marshal standard columns")
+	ErrMarshalIndex   = errors.New("failed to marshal index")
 
 	// Testing and debugging support.
 	verbose = func(fmt string, args ...interface{}) {}
@@ -46,21 +51,22 @@ func Verbose(v func(string, ...interface{})) {
 }
 
 // New returns a new instance of JSONLBundle.
-func New(bucket, gcsDataDir, gcsBaseID, datatype, dateSubdir string) *JSONLBundle {
+func New(bucket, gcsDataDir, gcsIndexDir, gcsBaseID, datatype, dateSubdir string) *JSONLBundle {
 	nowUTC := time.Now().UTC()
 	objName := fmt.Sprintf("%s-%s", nowUTC.Format("20060102T150405.000000Z"), gcsBaseID)
 	return &JSONLBundle{
 		Lines:      []string{},
+		BadFiles:   []string{},
+		Index:      []api.IndexV1{},
 		Timestamp:  nowUTC.Format("2006/01/02T150405.000000Z"),
 		Datatype:   datatype,
 		DateSubdir: dateSubdir,
-		bucket:     bucket,
-		ObjDir:     fmt.Sprintf("%s/date=%s", gcsDataDir, nowUTC.Format("2006-01-02")), // e.g., ndt/pcap/date=2022-09-14
-		ObjName:    objName + ".jsonl",
-		IdxName:    objName + ".index",
-		FullPaths:  []string{},
-		BadFiles:   []string{},
+		BundleDir:  fmt.Sprintf("%s/date=%s", gcsDataDir, nowUTC.Format("2006-01-02")), // e.g., ndt/pcap/date=2022-09-14
+		BundleName: objName + ".jsonl",
+		IndexDir:   fmt.Sprintf("%s/date=%s", gcsIndexDir, nowUTC.Format("2006-01-02")), // e.g., ndt/index1/date=2022-09-14
+		IndexName:  objName + ".index",
 		Size:       0,
+		bucket:     bucket,
 	}
 }
 
@@ -70,10 +76,15 @@ func (jb *JSONLBundle) Description() string {
 }
 
 // HasFile returns true or false depending on whether the bundle includes
-// the given file or not.
+// (or, for bad files, knows about) the given file or not.
 func (jb *JSONLBundle) HasFile(fullPath string) bool {
-	for _, p := range append(jb.FullPaths, jb.BadFiles...) {
-		if p == fullPath {
+	for _, index := range jb.Index {
+		if index.Filename == fullPath {
+			return true
+		}
+	}
+	for _, badFile := range jb.BadFiles {
+		if badFile == fullPath {
 			return true
 		}
 	}
@@ -82,6 +93,7 @@ func (jb *JSONLBundle) HasFile(fullPath string) bool {
 
 // AddFile adds the specified measurement data file in JSON format to
 // the bundle by embedding it in the Raw field of M-Lab's standard columns.
+// It also adds an index describing the file to the bundle's index.
 func (jb *JSONLBundle) AddFile(fullPath, version, gitCommit string) error {
 	contents, err := readJSONFile(fullPath)
 	if err != nil {
@@ -92,32 +104,70 @@ func (jb *JSONLBundle) AddFile(fullPath, version, gitCommit string) error {
 		Archiver: api.ArchiverV0{
 			Version:    version,
 			GitCommit:  gitCommit,
-			ArchiveURL: fmt.Sprintf("gs://%s/%s/%s", jb.bucket, jb.ObjDir, jb.ObjName),
+			ArchiveURL: fmt.Sprintf("gs://%s/%s/%s", jb.bucket, jb.BundleDir, jb.BundleName),
 			Filename:   fullPath,
 		},
 		Raw: "", // placeholder for measurement data
 	}
 	stdColsBytes, err := json.Marshal(stdCols)
 	if err != nil {
-		log.Panicf("failed to marshal standard columns: %v", err)
+		// log.Panicf("failed to marshal standard columns: %v", err) XXX Should we panic?
+		return fmt.Errorf("%v: %w", ErrMarshalStdCols, err)
 	}
 	// Replace the placeholder Raw with the actual measurement data.
 	line := strings.Replace(string(stdColsBytes), `"Raw":""`, `"Raw":`+contents, 1)
 	jb.Lines = append(jb.Lines, line)
-	jb.FullPaths = append(jb.FullPaths, fullPath)
+
+	// Add the file to the bundle's index.
+	jb.Index = append(jb.Index, api.IndexV1{
+		Filename:  fullPath,
+		Size:      len(line),
+		TimeAdded: time.Now().UTC().Format("2006/01/02T150405.000000Z"),
+	})
+
+	// Update bundle's size.
 	jb.Size += uint(len(line))
 	verbose("added %v to %v", fullPath, jb.Description())
 	return nil
+}
+
+// IndexFilenames returns all filenames in the index.
+func (jb *JSONLBundle) IndexFilenames() []string {
+	indexFilenames := make([]string, len(jb.Index))
+	for i, index := range jb.Index {
+		indexFilenames[i] = index.Filename
+	}
+	return indexFilenames
+}
+
+// MarshalIndex marshals the index.
+func (jb *JSONLBundle) MarshalIndex() ([]byte, error) {
+	marshaledIndex := make([]string, len(jb.Index))
+	for i, index := range jb.Index {
+		indexBytes, err := json.Marshal(index)
+		if err != nil {
+			// log.Panicf("failed to marshal index: %v", err) XXX Should we panic?
+			return nil, fmt.Errorf("%v: %w", ErrMarshalIndex, err)
+		}
+		marshaledIndex[i] = string(indexBytes)
+	}
+	return []byte(strings.Join(marshaledIndex, "\n")), nil
 }
 
 // RemoveLocalFiles removes files on the local filesystem that were
 // successfully uploaded via this bundle.  If a file cannot be removed,
 // an error message is logged but no further action is taken.
 func (jb *JSONLBundle) RemoveLocalFiles() {
-	for _, fullPath := range append(jb.FullPaths, jb.BadFiles...) {
-		verbose("removing %v", fullPath)
+	for _, index := range jb.Index {
+		verbose("removing uploaded data file %v", index.Filename)
+		if err := os.Remove(index.Filename); err != nil {
+			log.Printf("ERROR: failed to remove uploaded data file: %v\n", err)
+		}
+	}
+	for _, fullPath := range jb.BadFiles {
+		verbose("removing bad data file %v", fullPath)
 		if err := os.Remove(fullPath); err != nil {
-			log.Printf("ERROR: failed to remove: %v\n", err)
+			log.Printf("ERROR: failed to remove bad data file: %v\n", err)
 		}
 	}
 }

--- a/internal/jsonlbundle/jsonlbundle_test.go
+++ b/internal/jsonlbundle/jsonlbundle_test.go
@@ -176,7 +176,6 @@ func newTestJb(timestamp time.Time) *JSONLBundle {
 }
 
 func newJb(bucket, gcsDataDir, gcsIndexDir, gcsBaseID, datatype, dateSubdir string, timestamp time.Time) *JSONLBundle {
-	objName := fmt.Sprintf("%s-%s", timestamp.Format("20060102T150405.000000Z"), gcsBaseID)
 	return &JSONLBundle{
 		Lines:      []string{},
 		BadFiles:   []string{},
@@ -184,10 +183,10 @@ func newJb(bucket, gcsDataDir, gcsIndexDir, gcsBaseID, datatype, dateSubdir stri
 		Timestamp:  timestamp.Format("2006/01/02T150405.000000Z"),
 		Datatype:   datatype,
 		DateSubdir: dateSubdir,
-		BundleDir:  fmt.Sprintf("%s/date=%s", gcsDataDir, timestamp.Format("2006-01-02")), // e.g., ndt/pcap/date=2022-09-14
-		BundleName: objName + ".jsonl",
-		IndexDir:   fmt.Sprintf("%s/date=%s", gcsIndexDir, timestamp.Format("2006-01-02")), // e.g., ndt/index1/date=2022-09-14
-		IndexName:  objName + ".index",
+		BundleDir:  fmt.Sprintf("%s/date=%s", gcsDataDir, timestamp.Format("2006-01-02")),
+		BundleName: fmt.Sprintf("%s-%s-data.jsonl", timestamp.Format("20060102T150405.000000Z"), gcsBaseID),
+		IndexDir:   fmt.Sprintf("%s/date=%s", gcsIndexDir, timestamp.Format("2006-01-02")),
+		IndexName:  fmt.Sprintf("%s-%s-index1.jsonl", timestamp.Format("20060102T150405.000000Z"), gcsBaseID),
 		Size:       0,
 		bucket:     bucket,
 	}

--- a/internal/jsonlbundle/jsonlbundle_test.go
+++ b/internal/jsonlbundle/jsonlbundle_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/m-lab/jostler/api"
 	"github.com/m-lab/jostler/internal/testhelper"
 )
 
@@ -18,28 +19,31 @@ func TestVerbose(t *testing.T) { //nolint:paralleltest
 func TestNew(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		gcsBucket  string
-		gcsDataDir string
-		gcsBaseID  string
-		datatype   string
-		dateSubdir string
+		gcsBucket   string
+		gcsDataDir  string
+		gcsIndexDir string
+		gcsBaseID   string
+		datatype    string
+		dateSubdir  string
 	}{
 		{
-			gcsBucket:  "some-bucket",
-			gcsDataDir: "some/path/in/gcs",
-			gcsBaseID:  "some-string",
-			datatype:   "some-datatype",
-			dateSubdir: "2022/11/14",
+			gcsBucket:   "some-bucket",
+			gcsDataDir:  "some/path/in/gcs",
+			gcsIndexDir: "some/path/in/gcs",
+			gcsBaseID:   "some-string",
+			datatype:    "some-datatype",
+			dateSubdir:  "2022/11/14",
 		},
 	}
 	for i, test := range tests {
+		test := test
 		t.Logf("%s>>> test %02d%s", testhelper.ANSIPurple, i, testhelper.ANSIEnd)
-		gotjb := New(test.gcsBucket, test.gcsDataDir, test.gcsBaseID, test.datatype, test.dateSubdir)
+		gotjb := New(test.gcsBucket, test.gcsDataDir, test.gcsIndexDir, test.gcsBaseID, test.datatype, test.dateSubdir)
 		timestamp, err := time.Parse("2006/01/02T150405.000000Z", gotjb.Timestamp)
 		if err != nil {
 			t.Fatalf("time.Parse() = %v", err)
 		}
-		wantjb := newJb(test.gcsBucket, test.gcsDataDir, test.gcsBaseID, test.datatype, test.dateSubdir, timestamp)
+		wantjb := newJb(test.gcsBucket, test.gcsDataDir, test.gcsIndexDir, test.gcsBaseID, test.datatype, test.dateSubdir, timestamp)
 		if !reflect.DeepEqual(gotjb, wantjb) {
 			t.Fatalf("New() = %+v, want %+v", gotjb, wantjb)
 		}
@@ -59,12 +63,27 @@ func TestDescription(t *testing.T) {
 func TestHasFile(t *testing.T) {
 	t.Parallel()
 	jb := newTestJb(time.Now().UTC())
-	jb.FullPaths = []string{"file-1", "file-2", "file-3"}
-	if !jb.HasFile("file-2") {
-		t.Fatalf("jb.HasFile(file-2) = %v, want true", jb.HasFile("file-2"))
+	jb.Index = []api.IndexV1{
+		{Filename: "file-1", Size: 0, TimeAdded: ""},
+		{Filename: "file-2", Size: 0, TimeAdded: ""},
+		{Filename: "file-3", Size: 0, TimeAdded: ""},
 	}
-	if jb.HasFile("file-4") {
-		t.Fatalf("jb.HasFile(file-4) = %v, want false", jb.HasFile("file-4"))
+	jb.BadFiles = []string{"bad-file-1", "bad-file-2"}
+	tests := []struct {
+		file   string
+		exists bool
+	}{
+		{"file-2", true},
+		{"file-4", false},
+		{"bad-file-1", true},
+		{"bad-file-3", false},
+	}
+	for i, test := range tests {
+		test := test
+		t.Logf("%s>>> test %02d%s", testhelper.ANSIPurple, i, testhelper.ANSIEnd)
+		if exists := jb.HasFile(test.file); exists != test.exists {
+			t.Fatalf("jb.HasFile(%v) = %v, want %v", test.file, exists, test.exists)
+		}
 	}
 }
 
@@ -96,10 +115,12 @@ func TestAddFile(t *testing.T) { //nolint:paralleltest
 	}
 	jb := newTestJb(time.Now().UTC())
 	badFiles := 0
+	var wantIndex []string
 	for i, test := range tests {
 		t.Logf("%s>>> test %02d %v %s", testhelper.ANSIPurple, i, test.file, testhelper.ANSIEnd)
 		gotErr := jb.AddFile(test.file, "v0.1.2", "cafebabe")
 		if gotErr == nil && test.wantErr == nil {
+			wantIndex = append(wantIndex, test.file)
 			continue
 		}
 		if (gotErr != nil && test.wantErr == nil) ||
@@ -113,9 +134,16 @@ func TestAddFile(t *testing.T) { //nolint:paralleltest
 		if len(jb.BadFiles) != badFiles {
 			t.Fatalf("len(jb.BadFiles) = %v, want %v", len(jb.BadFiles), badFiles)
 		}
-		if len(jb.FullPaths) != i+1-badFiles {
-			t.Fatalf("len(jb.FullPaths) = %v, want %v", len(jb.FullPaths), i+1-badFiles)
+		if len(jb.Index) != i+1-badFiles {
+			t.Fatalf("len(jb.Index) = %v, want %v", len(jb.Index), i+1-badFiles)
 		}
+	}
+	gotIndex := jb.IndexFilenames()
+	if len(gotIndex) != len(wantIndex) {
+		t.Fatalf("len(gotIndex) = %v, want %v", len(gotIndex), len(wantIndex))
+	}
+	if _, err := jb.MarshalIndex(); err != nil {
+		t.Fatalf("jb.MarshalIndex() = %v, want nil", err)
 	}
 }
 
@@ -128,9 +156,11 @@ func TestRemoveLocalFiles(t *testing.T) { //nolint:paralleltest
 			t.Fatalf("os.WriteFile() = %v, want nil", err)
 		}
 	}
-	jb.FullPaths = fullPaths
+	for _, fullPath := range fullPaths {
+		jb.Index = append(jb.Index, api.IndexV1{Filename: fullPath, Size: 0, TimeAdded: ""})
+	}
 	// Add a non-existent file to force a remove error.
-	jb.FullPaths = append(jb.FullPaths, "testdata/non-existent-file")
+	jb.Index = append(jb.Index, api.IndexV1{Filename: "testdata/non-existent-file", Size: 0, TimeAdded: ""})
 	jb.BadFiles = badFiles
 	jb.RemoveLocalFiles()
 }
@@ -138,25 +168,27 @@ func TestRemoveLocalFiles(t *testing.T) { //nolint:paralleltest
 func newTestJb(timestamp time.Time) *JSONLBundle {
 	gcsBucket := "some-bucket"
 	gcsDataDir := "some/path/in/gcs"
+	gcsIndexDir := "some/path/in/gcs"
 	gcsBaseID := "some-string"
 	datatype := "some-datatype"
 	dateSubdir := "2022/11/14"
-	return newJb(gcsBucket, gcsDataDir, gcsBaseID, datatype, dateSubdir, timestamp)
+	return newJb(gcsBucket, gcsDataDir, gcsIndexDir, gcsBaseID, datatype, dateSubdir, timestamp)
 }
 
-func newJb(bucket, gcsDataDir, gcsBaseID, datatype, dateSubdir string, timestamp time.Time) *JSONLBundle {
+func newJb(bucket, gcsDataDir, gcsIndexDir, gcsBaseID, datatype, dateSubdir string, timestamp time.Time) *JSONLBundle {
 	objName := fmt.Sprintf("%s-%s", timestamp.Format("20060102T150405.000000Z"), gcsBaseID)
 	return &JSONLBundle{
 		Lines:      []string{},
+		BadFiles:   []string{},
+		Index:      []api.IndexV1{},
 		Timestamp:  timestamp.Format("2006/01/02T150405.000000Z"),
 		Datatype:   datatype,
 		DateSubdir: dateSubdir,
-		bucket:     bucket,
-		ObjDir:     fmt.Sprintf("%s/date=%s", gcsDataDir, timestamp.Format("2006-01-02")), // e.g., ndt/pcap/date=2022-09-14
-		ObjName:    objName + ".jsonl",
-		IdxName:    objName + ".index",
-		FullPaths:  []string{},
-		BadFiles:   []string{},
+		BundleDir:  fmt.Sprintf("%s/date=%s", gcsDataDir, timestamp.Format("2006-01-02")), // e.g., ndt/pcap/date=2022-09-14
+		BundleName: objName + ".jsonl",
+		IndexDir:   fmt.Sprintf("%s/date=%s", gcsIndexDir, timestamp.Format("2006-01-02")), // e.g., ndt/index1/date=2022-09-14
+		IndexName:  objName + ".index",
 		Size:       0,
+		bucket:     bucket,
 	}
 }

--- a/internal/uploadbundle/uploadbundle_test.go
+++ b/internal/uploadbundle/uploadbundle_test.go
@@ -26,7 +26,7 @@ func TestNew(t *testing.T) { //nolint:paralleltest
 		wdClient      *testhelper.WatchDir
 		gcsBucket     string
 		gcsDataDir    string
-		gcsBaseID     string
+		gcsDataBaseID string
 		bundleDataDir string
 		wantErr       error
 	}{
@@ -35,7 +35,7 @@ func TestNew(t *testing.T) { //nolint:paralleltest
 			wdClient:      nil,
 			gcsBucket:     "some-bucket",
 			gcsDataDir:    "some/path/in/gcs",
-			gcsBaseID:     "some-string",
+			gcsDataBaseID: "some-string",
 			bundleDataDir: "/some/path",
 			wantErr:       ErrConfig,
 		},
@@ -44,7 +44,7 @@ func TestNew(t *testing.T) { //nolint:paralleltest
 			wdClient:      wdClient,
 			gcsBucket:     "",
 			gcsDataDir:    "some/path/in/gcs",
-			gcsBaseID:     "some-string",
+			gcsDataBaseID: "some-string",
 			bundleDataDir: "/some/path",
 			wantErr:       ErrConfig,
 		},
@@ -53,16 +53,16 @@ func TestNew(t *testing.T) { //nolint:paralleltest
 			wdClient:      wdClient,
 			gcsBucket:     "some-bucket",
 			gcsDataDir:    "",
-			gcsBaseID:     "some-string",
+			gcsDataBaseID: "some-string",
 			bundleDataDir: "/some/path",
 			wantErr:       ErrConfig,
 		},
 		{
-			name:          "empty string gcsBaseID",
+			name:          "empty string gcsDataBaseID",
 			wdClient:      wdClient,
 			gcsBucket:     "some-bucket",
 			gcsDataDir:    "some/path/in/gcs",
-			gcsBaseID:     "",
+			gcsDataBaseID: "",
 			bundleDataDir: "/some/path",
 			wantErr:       ErrConfig,
 		},
@@ -71,7 +71,7 @@ func TestNew(t *testing.T) { //nolint:paralleltest
 			wdClient:      wdClient,
 			gcsBucket:     "some-bucket",
 			gcsDataDir:    "some/path/in/gcs",
-			gcsBaseID:     "some-string",
+			gcsDataBaseID: "some-string",
 			bundleDataDir: "",
 			wantErr:       ErrConfig,
 		},
@@ -80,7 +80,7 @@ func TestNew(t *testing.T) { //nolint:paralleltest
 			wdClient:      wdClient,
 			gcsBucket:     "newclient",
 			gcsDataDir:    "some/path/in/gcs",
-			gcsBaseID:     "some-string",
+			gcsDataBaseID: "some-string",
 			bundleDataDir: "/some/path",
 			wantErr:       nil,
 		},
@@ -94,11 +94,11 @@ func TestNew(t *testing.T) { //nolint:paralleltest
 			GCSClient: stClient,
 			Bucket:    test.gcsBucket,
 			DataDir:   test.gcsDataDir,
-			BaseID:    test.gcsBaseID,
+			BaseID:    test.gcsDataBaseID,
 		}
 		bundleConf := BundleConfig{
 			Datatype: "foo1",
-			DataDir:  test.bundleDataDir,
+			SpoolDir: test.bundleDataDir,
 			SizeMax:  20 * 1024 * 1024,
 			AgeMax:   1 * time.Hour,
 		}
@@ -217,12 +217,13 @@ func setupClients(t *testing.T, sizeMax uint, ageMax time.Duration) (*testhelper
 	gcsConf := GCSConfig{
 		GCSClient: stClient,
 		Bucket:    "newclient,upload",
-		DataDir:   "testdata/autoload/v1",
+		DataDir:   "testdata/autoload/v1/experiment/datatype",
+		IndexDir:  "testdata/autoload/v1/experiment/index1",
 		BaseID:    "some-string",
 	}
 	bundleConf := BundleConfig{
 		Datatype: "foo1",
-		DataDir:  "testdata/spool/jostler/foo1",
+		SpoolDir: "testdata/spool/jostler/foo1",
 		SizeMax:  sizeMax,
 		AgeMax:   ageMax,
 	}


### PR DESCRIPTION
With this commit, index bundles are created as JSONL bundles of index1 datatype.

The changes were tested locally with `go test -race ./...` and `test/e2e.sh`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/jostler/28)
<!-- Reviewable:end -->
