### PR TITLE
Create directory where data will be written to

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,35 +1,22 @@
 issues:
   exclude-rules:
-    - linters:
+    - path: test/
+      linters:
         - cyclop
-      path: test/
-    - linters:
         - forbidigo
-      path: testhelper/
-    - linters:
-        - forbidigo
-      path: test/
-    - linters:
         - funlen
-      path: _test.go
-    - linters:
-        - funlen
-      path: test/
-    - linters:
+        - gocyclo
         - gosec
-      path: test/
-    - linters:
-        - ireturn
-      path: _test.go
-    - linters:
-        - paralleltest
-      path: _test.go
-    - linters:
-        - testpackage
-      path: _test.go
-    - linters:
+    - path: testhelper/
+      linters:
+        - forbidigo
         - wrapcheck
-      path: testhelper/
+    - path: _test\.go
+      linters:
+        - funlen
+        - ireturn
+        - paralleltest
+        - testpackage
 linters-settings:
   cyclop:
     max-complexity: 15

--- a/cmd/jostler/main.go
+++ b/cmd/jostler/main.go
@@ -144,6 +144,10 @@ func daemonMode() error {
 // missed) files.
 func startWatcher(mainCtx context.Context, mainCancel context.CancelFunc, status chan<- error, datatype string, watchEvents []notify.Event) (*watchdir.WatchDir, error) {
 	watchDir := filepath.Join(localDataDir, experiment, datatype)
+	// Create the directory to watch if it doesn't already exist.
+	if err := os.MkdirAll(watchDir, 0o755); err != nil {
+		return nil, fmt.Errorf("failed to create directory: %w", err)
+	}
 	wdClient, err := watchdir.New(watchDir, extensions, watchEvents, missedAge, missedInterval)
 	if err != nil {
 		return nil, fmt.Errorf("failed to instantiate watcher: %w", err)


### PR DESCRIPTION
Because the order in which containers are started in a pod is not guaranteed, it's possible that the data directory where jostler has to watch isn't created by the measurement service yet causing it to exit.

This commit does the same thing that puhser does to address the race condition: it creates the directory if it doesn't already exist.

This commit also simplifies rules pertaining to test files in .golangci.yml.

Changes passed static analyzers and were tested locally.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/jostler/40)
<!-- Reviewable:end -->
