### PR TITLE
Use file timestamp for bundle

### DIFF
--- a/internal/jsonlbundle/jsonlbundle.go
+++ b/internal/jsonlbundle/jsonlbundle.go
@@ -35,6 +35,12 @@ type JSONLBundle struct {
 	Size       uint          // size of this bundle
 }
 
+// Time represents the time structure needed to create the JSONLBundles.
+type Time struct {
+	Time time.Time
+	Date civil.Date
+}
+
 // Exported errors.
 var (
 	ErrReadFile       = errors.New("failed to read file")
@@ -63,19 +69,18 @@ func Verbose(v func(string, ...interface{})) {
 //	|--------GCSConfig.DataDir--------|                                   |------GCSConfig.BaseID------|
 //	autoload/v1/<experiment>/index1/<yyyy>/<mm>/<dd>/<timestamp>-<datatype>-<node>-<experiment>-index1.jsonl
 //	|------GCSConfig.IndexDir-----|                                   |------GCSConfig.BaseID------|
-func New(bucket, gcsDataDir, gcsIndexDir, gcsBaseID, datatype string, date civil.Date) *JSONLBundle {
-	nowUTC := time.Now().UTC()
+func New(bucket, gcsDataDir, gcsIndexDir, gcsBaseID, datatype string, t *Time) *JSONLBundle {
 	return &JSONLBundle{
 		Lines:      []string{},
 		BadFiles:   []string{},
 		Index:      []api.IndexV1{},
-		Timestamp:  nowUTC.Format("2006/01/02T150405.000000Z"),
+		Timestamp:  t.Time.Format("2006/01/02T150405.000000Z"),
 		Datatype:   datatype,
-		Date:       date,
-		BundleDir:  dirName(gcsDataDir, nowUTC),
-		BundleName: objectName(nowUTC, gcsBaseID, "data"),
-		IndexDir:   dirName(gcsIndexDir, nowUTC),
-		IndexName:  objectName(nowUTC, gcsBaseID, "index1"),
+		Date:       t.Date,
+		BundleDir:  dirName(gcsDataDir, t.Time),
+		BundleName: objectName(t.Time, gcsBaseID, "data"),
+		IndexDir:   dirName(gcsIndexDir, t.Time),
+		IndexName:  objectName(t.Time, gcsBaseID, "index1"),
 		Size:       0,
 		bucket:     bucket,
 	}

--- a/internal/jsonlbundle/jsonlbundle_test.go
+++ b/internal/jsonlbundle/jsonlbundle_test.go
@@ -26,7 +26,7 @@ func TestNew(t *testing.T) {
 		gcsIndexDir string
 		gcsBaseID   string
 		datatype    string
-		date        civil.Date
+		time        *Time
 	}{
 		{
 			gcsBucket:   "some-bucket",
@@ -34,18 +34,20 @@ func TestNew(t *testing.T) {
 			gcsIndexDir: "some/path/in/gcs",
 			gcsBaseID:   "some-string",
 			datatype:    "some-datatype",
-			date:        civil.Date{Year: 2022, Month: time.November, Day: 14},
+			time: &Time{
+				Time: time.Date(2022, time.November, 14, 5, 3, 4, 0, time.UTC),
+				Date: civil.Date{Year: 2022, Month: time.November, Day: 14}},
 		},
 	}
 	for i, test := range tests {
 		test := test
 		t.Logf("%s>>> test %02d%s", testhelper.ANSIPurple, i, testhelper.ANSIEnd)
-		gotjb := New(test.gcsBucket, test.gcsDataDir, test.gcsIndexDir, test.gcsBaseID, test.datatype, test.date)
+		gotjb := New(test.gcsBucket, test.gcsDataDir, test.gcsIndexDir, test.gcsBaseID, test.datatype, test.time)
 		timestamp, err := time.Parse("2006/01/02T150405.000000Z", gotjb.Timestamp)
 		if err != nil {
 			t.Fatalf("time.Parse() = %v", err)
 		}
-		wantjb := newJb(test.gcsBucket, test.gcsDataDir, test.gcsIndexDir, test.gcsBaseID, test.datatype, test.date, timestamp)
+		wantjb := newJb(test.gcsBucket, test.gcsDataDir, test.gcsIndexDir, test.gcsBaseID, test.datatype, test.time.Date, timestamp)
 		if !reflect.DeepEqual(gotjb, wantjb) {
 			t.Fatalf("New() = %+v, want %+v", gotjb, wantjb)
 		}

--- a/internal/jsonlbundle/jsonlbundle_test.go
+++ b/internal/jsonlbundle/jsonlbundle_test.go
@@ -26,7 +26,7 @@ func TestNew(t *testing.T) {
 		gcsIndexDir string
 		gcsBaseID   string
 		datatype    string
-		time        *Time
+		date        civil.Date
 	}{
 		{
 			gcsBucket:   "some-bucket",
@@ -34,20 +34,18 @@ func TestNew(t *testing.T) {
 			gcsIndexDir: "some/path/in/gcs",
 			gcsBaseID:   "some-string",
 			datatype:    "some-datatype",
-			time: &Time{
-				Time: time.Date(2022, time.November, 14, 5, 3, 4, 0, time.UTC),
-				Date: civil.Date{Year: 2022, Month: time.November, Day: 14}},
+			date:        civil.Date{Year: 2022, Month: time.November, Day: 14},
 		},
 	}
 	for i, test := range tests {
 		test := test
 		t.Logf("%s>>> test %02d%s", testhelper.ANSIPurple, i, testhelper.ANSIEnd)
-		gotjb := New(test.gcsBucket, test.gcsDataDir, test.gcsIndexDir, test.gcsBaseID, test.datatype, test.time)
-		timestamp, err := time.Parse("2006/01/02T150405.000000Z", gotjb.Timestamp)
+		gotjb := New(test.gcsBucket, test.gcsDataDir, test.gcsIndexDir, test.gcsBaseID, test.datatype, test.date)
+		timestamp, err := time.Parse("2006/01/02/20060102T150405.000000Z", gotjb.Timestamp)
 		if err != nil {
 			t.Fatalf("time.Parse() = %v", err)
 		}
-		wantjb := newJb(test.gcsBucket, test.gcsDataDir, test.gcsIndexDir, test.gcsBaseID, test.datatype, test.time.Date, timestamp)
+		wantjb := newJb(test.gcsBucket, test.gcsDataDir, test.gcsIndexDir, test.gcsBaseID, test.datatype, test.date, timestamp)
 		if !reflect.DeepEqual(gotjb, wantjb) {
 			t.Fatalf("New() = %+v, want %+v", gotjb, wantjb)
 		}
@@ -58,7 +56,8 @@ func TestDescription(t *testing.T) {
 	t.Parallel()
 	nowUTC := time.Now().UTC()
 	jb := newTestJb(nowUTC)
-	wantDescription := fmt.Sprintf("bundle <%v %v %v>", nowUTC.Format("2006/01/02T150405.000000Z"), jb.Datatype, jb.Date)
+	timestamp := formatTimestamp(jb.Date, nowUTC)
+	wantDescription := fmt.Sprintf("bundle <%v %v %v>", timestamp, jb.Datatype, jb.Date)
 	if jb.Description() != wantDescription {
 		t.Fatalf("jb.Description() = %v, want %v", jb.Description(), wantDescription)
 	}
@@ -184,12 +183,12 @@ func newJb(bucket, gcsDataDir, gcsIndexDir, gcsBaseID, datatype string, date civ
 		Lines:      []string{},
 		BadFiles:   []string{},
 		Index:      []api.IndexV1{},
-		Timestamp:  timestamp.Format("2006/01/02T150405.000000Z"),
+		Timestamp:  formatTimestamp(date, timestamp),
 		Datatype:   datatype,
 		Date:       date,
-		BundleDir:  dirName(gcsDataDir, timestamp),
+		BundleDir:  dirName(gcsDataDir, date),
 		BundleName: objectName(timestamp, gcsBaseID, "data"),
-		IndexDir:   dirName(gcsIndexDir, timestamp),
+		IndexDir:   dirName(gcsIndexDir, date),
 		IndexName:  objectName(timestamp, gcsBaseID, "index1"),
 		Size:       0,
 		bucket:     bucket,
@@ -198,9 +197,9 @@ func newJb(bucket, gcsDataDir, gcsIndexDir, gcsBaseID, datatype string, date civ
 
 func Test_dirName(t *testing.T) {
 	dir := "gs://bucket/autoload/v1/experiment/datatype"
-	time := time.Date(2023, 03, 30, 4, 4, 0, 0, time.UTC)
+	date := civil.Date{Year: 2023, Month: 03, Day: 30}
 	want := dir + "/2023/03/30"
-	if got := dirName(dir, time); got != want {
+	if got := dirName(dir, date); got != want {
 		t.Errorf("dirName() = %v, want %v", got, want)
 	}
 }

--- a/internal/uploadbundle/uploadbundle.go
+++ b/internal/uploadbundle/uploadbundle.go
@@ -182,7 +182,7 @@ func (ub *UploadBundle) BundleAndUpload(ctx context.Context) error {
 func (ub *UploadBundle) bundleFile(ctx context.Context, fullPath string) {
 	// Validate the file's pathname and get its date subdirectory
 	// and size.
-	t, fileSize, err := ub.fileDetails(fullPath)
+	date, fileSize, err := ub.fileDetails(fullPath)
 	if err != nil {
 		verbose("WARNING: ignoring %v: %v", fullPath, err)
 		return
@@ -190,7 +190,7 @@ func (ub *UploadBundle) bundleFile(ctx context.Context, fullPath string) {
 	verbose("%v %v bytes", fullPath, fileSize)
 
 	// Is there an active bundle that this file belongs to?
-	jb := ub.activeBundles[t.Date]
+	jb := ub.activeBundles[date]
 	if jb != nil {
 		// Sanity check.
 		if jb.HasFile(fullPath) {
@@ -206,7 +206,7 @@ func (ub *UploadBundle) bundleFile(ctx context.Context, fullPath string) {
 		}
 	}
 	if jb == nil {
-		jb = ub.newJSONLBundle(t)
+		jb = ub.newJSONLBundle(date)
 	}
 	// Add the contents of this file to the bundle.
 	if err := jb.AddFile(fullPath, ub.bundleConf.Version, ub.bundleConf.GitCommit); err != nil {
@@ -221,67 +221,63 @@ func (ub *UploadBundle) bundleFile(ctx context.Context, fullPath string) {
 // and is a regular file.  Then it makes sure it's not too big.
 // If all is OK, it returns the date component of the file's pathname
 // ("yyyy/mm/dd") as a civil.Date with the file size.
-func (ub *UploadBundle) fileDetails(fullPath string) (*jsonlbundle.Time, int64, error) {
+func (ub *UploadBundle) fileDetails(fullPath string) (civil.Date, int64, error) {
 	cleanFilePath := filepath.Clean(fullPath)
 	dataDir := ub.bundleConf.SpoolDir
 	if !strings.HasPrefix(cleanFilePath, dataDir) {
-		return nil, 0, fmt.Errorf("%v: %w", cleanFilePath, ErrNotInDataDir)
+		return civil.Date{}, 0, fmt.Errorf("%v: %w", cleanFilePath, ErrNotInDataDir)
 	}
 	if len(cleanFilePath) <= len(dataDir) {
-		return nil, 0, fmt.Errorf("%v: %w", cleanFilePath, ErrTooShort)
+		return civil.Date{}, 0, fmt.Errorf("%v: %w", cleanFilePath, ErrTooShort)
 	}
 	pathName := regexp.MustCompile(`[^a-zA-Z0-9/:._-]`)
 	if pathName.MatchString(cleanFilePath) {
-		return nil, 0, fmt.Errorf("%v: %w", cleanFilePath, ErrInvalidChars)
+		return civil.Date{}, 0, fmt.Errorf("%v: %w", cleanFilePath, ErrInvalidChars)
 	}
 	if strings.Contains(cleanFilePath, "..") {
-		return nil, 0, fmt.Errorf("%v: %w", cleanFilePath, ErrDotDot)
+		return civil.Date{}, 0, fmt.Errorf("%v: %w", cleanFilePath, ErrDotDot)
 	}
 	dateSubdir, filename := filepath.Split(cleanFilePath[len(dataDir):])
 	yyyymmdd := regexp.MustCompile(`/20[0-9][0-9]/[0-9]{2}/[0-9]{2}/`)
 	if len(dateSubdir) != 12 || !yyyymmdd.MatchString(dateSubdir) {
-		return nil, 0, fmt.Errorf("%v: %w", cleanFilePath, ErrDateDir)
+		return civil.Date{}, 0, fmt.Errorf("%v: %w", cleanFilePath, ErrDateDir)
 	}
 	if strings.HasPrefix(filename, ".") {
-		return nil, 0, fmt.Errorf("%v: %w", filename, ErrDotFile)
+		return civil.Date{}, 0, fmt.Errorf("%v: %w", filename, ErrDotFile)
 	}
 	fi, err := os.Stat(fullPath)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to stat: %w", err)
+		return civil.Date{}, 0, fmt.Errorf("failed to stat: %w", err)
 	}
 	if !fi.Mode().IsRegular() {
-		return nil, 0, fmt.Errorf("%v: %w", filename, ErrNotRegular)
+		return civil.Date{}, 0, fmt.Errorf("%v: %w", filename, ErrNotRegular)
 	}
 	if uint(fi.Size()) == 0 {
-		return nil, 0, fmt.Errorf("%v: %w", filename, ErrEmpty)
+		return civil.Date{}, 0, fmt.Errorf("%v: %w", filename, ErrEmpty)
 	}
 	if uint(fi.Size()) > ub.bundleConf.SizeMax {
-		return nil, 0, fmt.Errorf("%v: %w", filename, ErrTooBig)
+		return civil.Date{}, 0, fmt.Errorf("%v: %w", filename, ErrTooBig)
 	}
 	date, err := civil.ParseDate(strings.ReplaceAll(dateSubdir[1:11], "/", "-"))
 	if err != nil {
-		return nil, 0, fmt.Errorf("%v: %w", filename, ErrDateParse)
+		return civil.Date{}, 0, fmt.Errorf("%v: %w", filename, ErrDateParse)
 	}
-	timestamp, err := time.Parse("20060102T150405.000000Z", filename)
-	if err != nil {
-		return nil, 0, err
-	}
-	return &jsonlbundle.Time{Date: date, Time: timestamp}, fi.Size(), nil
+	return date, fi.Size(), nil
 }
 
 // newJSONLBundle creates and returns a new active bundle instance.
-func (ub *UploadBundle) newJSONLBundle(t *jsonlbundle.Time) *jsonlbundle.JSONLBundle {
+func (ub *UploadBundle) newJSONLBundle(date civil.Date) *jsonlbundle.JSONLBundle {
 	// Sanity check: make sure we don't already have a bundle for
 	// the given date.
-	if jb, ok := ub.activeBundles[t.Date]; ok {
-		if t.Date == jb.Date {
+	if jb, ok := ub.activeBundles[date]; ok {
+		if date == jb.Date {
 			log.Printf("INTERNAL ERROR: an active %v already exists", jb.Description())
 		}
-		log.Printf("INTERNAL ERROR: key %s returned active %v", t.Date, jb.Description())
+		log.Printf("INTERNAL ERROR: key %s returned active %v", date, jb.Description())
 	}
 
-	jb := jsonlbundle.New(ub.gcsConf.Bucket, ub.gcsConf.DataDir, ub.gcsConf.IndexDir, ub.gcsConf.BaseID, ub.bundleConf.Datatype, t)
-	ub.activeBundles[t.Date] = jb
+	jb := jsonlbundle.New(ub.gcsConf.Bucket, ub.gcsConf.DataDir, ub.gcsConf.IndexDir, ub.gcsConf.BaseID, ub.bundleConf.Datatype, date)
+	ub.activeBundles[date] = jb
 	verbose("created active %v", jb.Description())
 	time.AfterFunc(ub.bundleConf.AgeMax, func() {
 		ub.ageChan <- jb


### PR DESCRIPTION
This PR changes the `Timestamp` format to be of the form 2023/04/03/20230404T154435.729707Z, where the prefix (2023/04/03) comes from the filepath date (e.g., var/spool/experiment/datatype/2023/04/03) and the suffix (20230404T154435.729707Z) comes from time.Now().

This is done to differentiate bundles created on the same day containing measurements collected on different dates.

The `Timestamp` field is only used internally for logging and as a key for the [`uploadBundles` ](https://github.com/m-lab/jostler/blob/976d65198b601975dd8cdd00f63b5531a28c046f/internal/uploadbundle/uploadbundle.go#L294)map to associate bundles being uploaded to specific date paths. 

It also changes the data and index paths to use the measurement date (instead of `time.Now()`) in their filepath date in GCS (e.g., gs://archive-mlab-sandbox/autoload/v1/host/nodeinfo1/**2023/04/03**/20230403T235820.627855Z-nodeinfo1-mlab4-lga1t-host-data.jsonl.gz).


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/jostler/47)
<!-- Reviewable:end -->
