### PR TITLE
Add support for autoload/v2 conventions to jostler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
 - go vet ./...
 - CGO_ENABLED=0 go build ./...
 - go test ./... -race
-- go test ./... -v -coverprofile=_coverage.cov
+- go test ./... -v -covermode=count -coverprofile=_coverage.cov
 
 after_success:
 # Coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
 - go vet ./...
 - CGO_ENABLED=0 go build ./...
 - go test ./... -race
-- go test ./... -v -covermode=count -coverprofile=_coverage.cov
+- go test ./... -v -covermode=atomic -coverprofile=_coverage.cov
 
 after_success:
 # Coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
 - go vet ./...
 - CGO_ENABLED=0 go build ./...
 - go test ./... -race
-- go test ./... -v -covermode=atomic -coverprofile=_coverage.cov
+- go test ./... -v -covermode=count -coverprofile=_coverage.cov
 
 after_success:
 # Coveralls

--- a/cmd/jostler/cli.go
+++ b/cmd/jostler/cli.go
@@ -69,7 +69,7 @@ func initFlags() {
 	flag.StringVar(&gcsDataDir, "gcs-data-dir", "autoload/v1", "home directory in GCS bucket under which bundles will be uploaded")
 	flag.StringVar(&mlabNodeName, "mlab-node-name", "", "required - node name specified directly or via MLAB_NODE_NAME env variable")
 	flag.StringVar(&organization, "organization", "", "the organization name; required for autoload/v2 conventions")
-	flag.BoolVar(&uploadSchema, "upload-schema", true, "upload the local table schema")
+	flag.BoolVar(&uploadSchema, "upload-schema", true, "upload the local table schema if necessary")
 
 	// Flags related to bundles.
 	dtSchemaFiles = flagx.StringArray{}

--- a/cmd/jostler/cli.go
+++ b/cmd/jostler/cli.go
@@ -24,6 +24,7 @@ var (
 	gcsDataDir   string
 	mlabNodeName string
 	organization string
+	uploadSchema bool = true
 
 	// Flags related to bundles.
 	dtSchemaFiles flagx.StringArray
@@ -68,6 +69,7 @@ func initFlags() {
 	flag.StringVar(&gcsDataDir, "gcs-data-dir", "autoload/v1", "home directory in GCS bucket under which bundles will be uploaded")
 	flag.StringVar(&mlabNodeName, "mlab-node-name", "", "required - node name specified directly or via MLAB_NODE_NAME env variable")
 	flag.StringVar(&organization, "organization", "", "the organization name; required for autoload/v2 conventions")
+	flag.BoolVar(&uploadSchema, "upload-schema", true, "upload the local table schema")
 
 	// Flags related to bundles.
 	dtSchemaFiles = flagx.StringArray{}

--- a/cmd/jostler/main.go
+++ b/cmd/jostler/main.go
@@ -105,6 +105,7 @@ func daemonMode() error {
 	// ones are a superset of the previous table.
 	for _, datatype := range datatypes {
 		dtSchemaFile := schema.PathForDatatype(datatype, dtSchemaFiles)
+		// TODO(soltesz): simplify the supporting logic for the validate & upload cases.
 		if uploadSchema {
 			// For autoload/v1 conventions and authoritative autoload/v2 configurations.
 			err = schema.ValidateAndUpload(stClient, bucket, experiment, datatype, dtSchemaFile)

--- a/cmd/jostler/main.go
+++ b/cmd/jostler/main.go
@@ -106,13 +106,13 @@ func daemonMode() error {
 	for _, datatype := range datatypes {
 		dtSchemaFile := schema.PathForDatatype(datatype, dtSchemaFiles)
 		if uploadSchema {
-			// Use autoload/v1 conventions, and authoritative autoload/v2 configurations.
+			// For autoload/v1 conventions and authoritative autoload/v2 configurations.
 			err = schema.ValidateAndUpload(stClient, bucket, experiment, datatype, dtSchemaFile)
 		} else {
+			// For autoload/v2 conventions without local schema uploads.
 			var status schema.SchemaStatus
-			// Use autoload/v2 conventions, without uploading local schemas.
 			status, err = schema.Validate(stClient, bucket, experiment, datatype, dtSchemaFile)
-			// Allow backward compatible local schemas. Note: local schemas that are new will cause an error.
+			// Allow backward compatible local schemas. NOTE: local schemas that are new will cause an error.
 			if status == schema.SchemaBackwardCompatible {
 				err = nil
 			}

--- a/cmd/jostler/main.go
+++ b/cmd/jostler/main.go
@@ -110,9 +110,9 @@ func daemonMode() error {
 			err = schema.ValidateAndUpload(stClient, bucket, experiment, datatype, dtSchemaFile)
 		} else {
 			// For autoload/v2 conventions without local schema uploads.
-			status, xerr := schema.Validate(stClient, bucket, experiment, datatype, dtSchemaFile)
+			xerr := schema.Validate(stClient, bucket, experiment, datatype, dtSchemaFile)
 			// Allow backward compatible local schemas. NOTE: local schemas that are new will cause an error.
-			if status == schema.SchemaBackwardCompatible {
+			if errors.Is(xerr, schema.ErrOnlyInOld) || errors.Is(xerr, schema.ErrSchemaMatch) {
 				err = nil
 			} else {
 				err = xerr

--- a/cmd/jostler/main.go
+++ b/cmd/jostler/main.go
@@ -106,13 +106,14 @@ func daemonMode() error {
 	for _, datatype := range datatypes {
 		dtSchemaFile := schema.PathForDatatype(datatype, dtSchemaFiles)
 		if organization == "" {
+			// Use autoload/v1 conventions.
 			err = schema.ValidateAndUpload(stClient, bucket, experiment, datatype, dtSchemaFile)
 		} else {
-			// Use autoload/v2 conventions, do not upload local schema.
-			var status schema.SchemaStatus
-			status, err = schema.Validate(stClient, bucket, experiment, datatype, dtSchemaFile)
+			// Use autoload/v2 conventions; do not upload local schemas.
+			status, verr := schema.Validate(stClient, bucket, experiment, datatype, dtSchemaFile)
+			err = verr
+			// Allow backward compatible local schemas. Note: local schemas that are new will cause an error.
 			if status == schema.SchemaBackwardCompatible {
-				// Allow backward compatible local schemas.
 				err = nil
 			}
 		}

--- a/cmd/jostler/main.go
+++ b/cmd/jostler/main.go
@@ -105,13 +105,13 @@ func daemonMode() error {
 	// ones are a superset of the previous table.
 	for _, datatype := range datatypes {
 		dtSchemaFile := schema.PathForDatatype(datatype, dtSchemaFiles)
-		if organization == "" {
-			// Use autoload/v1 conventions.
+		if uploadSchema {
+			// Use autoload/v1 conventions, and authoritative autoload/v2 configurations.
 			err = schema.ValidateAndUpload(stClient, bucket, experiment, datatype, dtSchemaFile)
 		} else {
-			// Use autoload/v2 conventions; do not upload local schemas.
-			status, verr := schema.Validate(stClient, bucket, experiment, datatype, dtSchemaFile)
-			err = verr
+			var status schema.SchemaStatus
+			// Use autoload/v2 conventions, without uploading local schemas.
+			status, err = schema.Validate(stClient, bucket, experiment, datatype, dtSchemaFile)
 			// Allow backward compatible local schemas. Note: local schemas that are new will cause an error.
 			if status == schema.SchemaBackwardCompatible {
 				err = nil

--- a/cmd/jostler/main.go
+++ b/cmd/jostler/main.go
@@ -110,11 +110,12 @@ func daemonMode() error {
 			err = schema.ValidateAndUpload(stClient, bucket, experiment, datatype, dtSchemaFile)
 		} else {
 			// For autoload/v2 conventions without local schema uploads.
-			var status schema.SchemaStatus
-			status, err = schema.Validate(stClient, bucket, experiment, datatype, dtSchemaFile)
+			status, xerr := schema.Validate(stClient, bucket, experiment, datatype, dtSchemaFile)
 			// Allow backward compatible local schemas. NOTE: local schemas that are new will cause an error.
 			if status == schema.SchemaBackwardCompatible {
 				err = nil
+			} else {
+				err = xerr
 			}
 		}
 		if err != nil {

--- a/cmd/jostler/main_test.go
+++ b/cmd/jostler/main_test.go
@@ -142,6 +142,7 @@ func TestCLI(t *testing.T) {
 				"-experiment", testExperiment,
 				"-datatype", "foo1",
 				"-datatype-schema-file", "foo1:testdata/datatypes/foo1-valid.json",
+				"-gcs-data-dir=testdata/autoload/v1",
 			},
 		},
 		{
@@ -153,6 +154,7 @@ func TestCLI(t *testing.T) {
 				"-experiment", testExperiment,
 				"-datatype", "foo1",
 				"-datatype-schema-file", "foo1:testdata/datatypes/foo1-valid.json",
+				"-gcs-data-dir=testdata/autoload/v1",
 			},
 		},
 		{
@@ -164,6 +166,7 @@ func TestCLI(t *testing.T) {
 				"-experiment", testExperiment,
 				"-datatype", "foo1",
 				"-datatype-schema-file", "foo1:testdata/datatypes/foo1-valid-superset.json",
+				"-gcs-data-dir=testdata/autoload/v1",
 			},
 		},
 		{
@@ -175,6 +178,34 @@ func TestCLI(t *testing.T) {
 				"-experiment", testExperiment,
 				"-datatype", "foo1",
 				"-datatype-schema-file", "foo1:testdata/datatypes/foo1-valid.json",
+				"-gcs-data-dir=testdata/autoload/v1",
+			},
+		},
+		// Invalid autoloading configurations.
+		{
+			"invalid: scenario 1", false, errAutoloadOrgInvalid.Error(),
+			[]string{
+				"-gcs-bucket", "newclient,download",
+				"-mlab-node-name", testNode,
+				"-local-data-dir", testLocalDataDir,
+				"-experiment", testExperiment,
+				"-datatype", "foo1",
+				"-datatype-schema-file", "foo1:testdata/datatypes/foo1-valid.json",
+				"-gcs-data-dir=testdata/autoload/v1",
+				"-organization=bar1", // Should not specify organization for an autoload/v1 run.
+			},
+		},
+		{
+			"invalid: scenario 2", true, errAutoloadOrgRequired.Error(),
+			[]string{
+				"-gcs-bucket", "newclient,download",
+				"-mlab-node-name", testNode,
+				"-local-data-dir", testLocalDataDir,
+				"-experiment", testExperiment,
+				"-datatype", "foo1",
+				"-datatype-schema-file", "foo1:testdata/datatypes/foo1-valid.json",
+				"-gcs-data-dir=testdata/autoload/v2", // any value other than autoload/v1.
+				"-organization=",                     // Organization is required.
 			},
 		},
 	}
@@ -183,6 +214,7 @@ func TestCLI(t *testing.T) {
 		os.RemoveAll("testdata/autoload")
 	}()
 	for i, test := range tests {
+		t.Logf("name: %s", test.name)
 		if test.rmTblSchemaFile {
 			os.RemoveAll("testdata/autoload/v1/tables/jostler/foo1.table.json")
 		}
@@ -196,7 +228,7 @@ func TestCLI(t *testing.T) {
 		args := test.args
 		// Use a local disk storage implementation that mimics downloads
 		// from and uploads to GCS.
-		args = append(args, []string{"-gcs-local-disk", "-gcs-data-dir", "testdata/autoload/v1"}...)
+		args = append(args, []string{"-gcs-local-disk"}...)
 		if testing.Verbose() {
 			args = append(args, "-verbose")
 		}

--- a/cmd/jostler/main_test.go
+++ b/cmd/jostler/main_test.go
@@ -236,7 +236,7 @@ func TestCLI(t *testing.T) {
 			},
 		},
 		{
-			"invalid: scenario 4 - cannot upload new v2 schema", false, "foo1: schema differences:  1 difference(s) in schema new fields",
+			"invalid: scenario 4 - cannot upload new v2 schema", false, schema.ErrNewFields.Error(),
 			[]string{
 				"-gcs-bucket", "newclient,download",
 				"-mlab-node-name", testNode,

--- a/cmd/jostler/main_test.go
+++ b/cmd/jostler/main_test.go
@@ -208,6 +208,7 @@ func TestCLI(t *testing.T) {
 				"-organization=",                     // Organization is required.
 			},
 		},
+		// TODO: add a v2 new schema.
 	}
 	defer func() {
 		os.RemoveAll("foo1.json")

--- a/cmd/jostler/main_test.go
+++ b/cmd/jostler/main_test.go
@@ -208,7 +208,47 @@ func TestCLI(t *testing.T) {
 				"-organization=",                     // Organization is required.
 			},
 		},
-		// TODO: add a v2 new schema.
+		{
+			"invalid: scenario 3", true, errOrgName.Error(),
+			[]string{
+				"-gcs-bucket", "newclient,download",
+				"-mlab-node-name", testNode,
+				"-local-data-dir", testLocalDataDir,
+				"-experiment", testExperiment,
+				"-datatype", "foo1",
+				"-datatype-schema-file", "foo1:testdata/datatypes/foo1-valid.json",
+				"-gcs-data-dir=testdata/autoload/v2", // any value other than autoload/v1.
+				"-organization=INVALIDNAME",          // Organization is invalid.
+			},
+		},
+		{
+			"valid: scenario 4 - upload authoritative new schema", true, "",
+			[]string{
+				"-gcs-bucket", "newclient,download,upload",
+				"-mlab-node-name", testNode,
+				"-local-data-dir", testLocalDataDir,
+				"-experiment", testExperiment,
+				"-datatype", "foo1",
+				"-datatype-schema-file", "foo1:testdata/datatypes/foo1-valid.json",
+				"-gcs-data-dir=testdata/autoload/v2",
+				"-organization=foo1org",
+				"-upload-schema=true", // allow uploads.
+			},
+		},
+		{
+			"invalid: scenario 4 - cannot upload new v2 schema", false, "foo1: schema differences:  1 difference(s) in schema new fields",
+			[]string{
+				"-gcs-bucket", "newclient,download",
+				"-mlab-node-name", testNode,
+				"-local-data-dir", testLocalDataDir,
+				"-experiment", testExperiment,
+				"-datatype", "foo1",
+				"-datatype-schema-file", "foo1:testdata/datatypes/foo1-valid-superset.json", // superset schema.
+				"-gcs-data-dir=testdata/autoload/v2",
+				"-organization=foo1org",
+				"-upload-schema=false", // do not allow uploads.
+			},
+		},
 	}
 	defer func() {
 		os.RemoveAll("foo1.json")

--- a/cmd/jostler/main_test.go
+++ b/cmd/jostler/main_test.go
@@ -258,6 +258,7 @@ func TestCLI(t *testing.T) {
 		t.Logf("name: %s", test.name)
 		if test.rmTblSchemaFile {
 			os.RemoveAll("testdata/autoload/v1/tables/jostler/foo1.table.json")
+			os.RemoveAll("testdata/autoload/v2/tables/jostler/foo1.table.json")
 		}
 		var s string
 		if test.wantErrStr == "" {

--- a/cmd/jostler/main_test.go
+++ b/cmd/jostler/main_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/m-lab/go/prometheusx"
 	"github.com/m-lab/jostler/internal/schema"
 	"github.com/m-lab/jostler/internal/testhelper"
 )
@@ -30,6 +31,9 @@ var (
 
 // TestCLI tests non-interactive CLI invocations.
 func TestCLI(t *testing.T) {
+	// Prevent "bind: address already in use" errors during tests.
+	addr := ":0"
+	prometheusx.ListenAddress = &addr
 	tests := []struct {
 		name            string   // name of the test
 		rmTblSchemaFile bool     // if true, remove table schema file before running the test

--- a/cmd/jostler/main_test.go
+++ b/cmd/jostler/main_test.go
@@ -146,7 +146,7 @@ func TestCLI(t *testing.T) {
 			},
 		},
 		{
-			"daemon: scenario 2", false, "",
+			"daemon: scenario 2", false, schema.ErrSchemaMatch.Error(),
 			[]string{
 				"-gcs-bucket", "newclient,download",
 				"-mlab-node-name", testNode,
@@ -181,7 +181,7 @@ func TestCLI(t *testing.T) {
 				"-gcs-data-dir=testdata/autoload/v1",
 			},
 		},
-		// Invalid autoloading configurations.
+		// autoload/v2 flag and configuration testing.
 		{
 			"invalid: scenario 1", false, errAutoloadOrgInvalid.Error(),
 			[]string{
@@ -236,6 +236,20 @@ func TestCLI(t *testing.T) {
 			},
 		},
 		{
+			"valid: scenario 4 - allow matching schema without upload", false, "",
+			[]string{
+				"-gcs-bucket", "newclient,download,upload",
+				"-mlab-node-name", testNode,
+				"-local-data-dir", testLocalDataDir,
+				"-experiment", testExperiment,
+				"-datatype", "foo1",
+				"-datatype-schema-file", "foo1:testdata/datatypes/foo1-valid.json",
+				"-gcs-data-dir=testdata/autoload/v2",
+				"-organization=foo1org",
+				"-upload-schema=false",
+			},
+		},
+		{
 			"invalid: scenario 4 - cannot upload new v2 schema", false, schema.ErrNewFields.Error(),
 			[]string{
 				"-gcs-bucket", "newclient,download",
@@ -246,7 +260,35 @@ func TestCLI(t *testing.T) {
 				"-datatype-schema-file", "foo1:testdata/datatypes/foo1-valid-superset.json", // superset schema.
 				"-gcs-data-dir=testdata/autoload/v2",
 				"-organization=foo1org",
-				"-upload-schema=false", // do not allow uploads.
+				"-upload-schema=false",
+			},
+		},
+		{
+			"valid: scenario 5 - upload newer authoritative new schema", true, "",
+			[]string{
+				"-gcs-bucket", "newclient,download,upload",
+				"-mlab-node-name", testNode,
+				"-local-data-dir", testLocalDataDir,
+				"-experiment", testExperiment,
+				"-datatype", "foo1",
+				"-datatype-schema-file", "foo1:testdata/datatypes/foo1-valid-superset.json",
+				"-gcs-data-dir=testdata/autoload/v2",
+				"-organization=foo1org",
+				"-upload-schema=true", // allow uploads.
+			},
+		},
+		{
+			"valid: scenario 5 - allow backward compatible schema", false, "",
+			[]string{
+				"-gcs-bucket", "newclient,download,upload",
+				"-mlab-node-name", testNode,
+				"-local-data-dir", testLocalDataDir,
+				"-experiment", testExperiment,
+				"-datatype", "foo1",
+				"-datatype-schema-file", "foo1:testdata/datatypes/foo1-valid.json",
+				"-gcs-data-dir=testdata/autoload/v2",
+				"-organization=foo1org",
+				"-upload-schema=false",
 			},
 		},
 	}

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -155,7 +155,7 @@ func TestValidateAndUpload(t *testing.T) {
 			experiment:      testExperiment,
 			datatype:        testDatatype,
 			dtSchemaFile:    "testdata/datatypes/foo1-valid.json",
-			wantErr:         nil,
+			wantErr:         schema.ErrSchemaMatch,
 		},
 		{
 			name:            "scenario 3 - old exists, new is a superset, should upload",


### PR DESCRIPTION
This change adds flags to make jostler compatible with autoload/v2 conventions while remaining backward compatible for autoload/v1 conventions.

This change introduces two new flags.
* `-upload-schema=<bool>` -- preserves the default behavior for autoload/v1 usage and allows for an authoritative source for autoload/v2 schemas.
* `-organization=<str>` -- required and only valid for non-autoload/v1 configurations. This flag is ignored for autoload/v1 configurations.

As a result of these changes, there are practically three modes that jostler is expected to support:
* autoload/v1 - e.g. as used on M-Lab platform today.
* autoload/v2 as authoritative source for table schemas - e.g. the upstream schema source for BYOS schemas.
* autoload/v2 as downstream contributor for existing table schemas - e.g. most BYOS deployments.

These changes do not yet support in-band, per-organization schemas. This will be part of future work.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/jostler/51)
<!-- Reviewable:end -->
