### PR TITLE
Simplify the ValidateAndUpload logic

### DIFF
--- a/cmd/jostler/main.go
+++ b/cmd/jostler/main.go
@@ -105,20 +105,7 @@ func daemonMode() error {
 	// ones are a superset of the previous table.
 	for _, datatype := range datatypes {
 		dtSchemaFile := schema.PathForDatatype(datatype, dtSchemaFiles)
-		// TODO(soltesz): simplify the supporting logic for the validate & upload cases.
-		if uploadSchema {
-			// For autoload/v1 conventions and authoritative autoload/v2 configurations.
-			err = schema.ValidateAndUpload(stClient, bucket, experiment, datatype, dtSchemaFile)
-		} else {
-			// For autoload/v2 conventions without local schema uploads.
-			xerr := schema.Validate(stClient, bucket, experiment, datatype, dtSchemaFile)
-			// Allow backward compatible local schemas. NOTE: local schemas that are new will cause an error.
-			if errors.Is(xerr, schema.ErrOnlyInOld) || errors.Is(xerr, schema.ErrSchemaMatch) {
-				err = nil
-			} else {
-				err = xerr
-			}
-		}
+		err := schema.ValidateAndUpload(stClient, bucket, experiment, datatype, dtSchemaFile, uploadSchema)
 		if err != nil {
 			mainCancel()
 			return fmt.Errorf("%v: %w", datatype, err)

--- a/cmd/jostler/main_test.go
+++ b/cmd/jostler/main_test.go
@@ -150,7 +150,7 @@ func TestCLI(t *testing.T) {
 			},
 		},
 		{
-			"daemon: scenario 2", false, schema.ErrSchemaMatch.Error(),
+			"daemon: scenario 2", false, "",
 			[]string{
 				"-gcs-bucket", "newclient,download",
 				"-mlab-node-name", testNode,

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -117,7 +117,7 @@ func CreateTableSchemaJSON(datatype, dtSchemaFile string) ([]byte, error) {
 // compatibale. If the new table schema is a superset of the previous one, it
 // will be uploaded to GCS.
 func ValidateAndUpload(gcsClient DownloaderUploader, bucket, experiment, datatype, dtSchemaFile string, uploadSchema bool) error {
-	err := Validate(gcsClient, bucket, experiment, datatype, dtSchemaFile)
+	err := validate(gcsClient, bucket, experiment, datatype, dtSchemaFile)
 	if uploadSchema && (errors.Is(err, ErrSchemaNotFound) || errors.Is(err, ErrNewFields)) {
 		// For autoload/v1 conventions and authoritative autoload/v2 configurations.
 		// Upload when the schema is not found or there are new local fields in the schema.
@@ -134,10 +134,10 @@ func ValidateAndUpload(gcsClient DownloaderUploader, bucket, experiment, datatyp
 	return err
 }
 
-// Validate checks the given table schema against the previous table schema for
+// validate checks the given table schema against the previous table schema for
 // various differences and returns a SchemaStatus corresponding to the
 // difference.
-func Validate(gcsClient DownloaderUploader, bucket, experiment, datatype, dtSchemaFile string) error {
+func validate(gcsClient DownloaderUploader, bucket, experiment, datatype, dtSchemaFile string) error {
 	if err := ValidateSchemaFile(dtSchemaFile); err != nil {
 		return fmt.Errorf("%v: %w", err, ErrInvalidSchema)
 	}

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -84,6 +84,7 @@ func TestValidateAndUpload(t *testing.T) {
 		experiment      string
 		datatype        string
 		dtSchemaFile    string
+		uploadSchema    bool
 
 		wantErr error
 	}{
@@ -95,6 +96,7 @@ func TestValidateAndUpload(t *testing.T) {
 			experiment:      testExperiment,
 			datatype:        testDatatype,
 			dtSchemaFile:    "testdata/datatypes/non-existent.json", // this file doesn't exist
+			uploadSchema:    true,
 			wantErr:         schema.ErrReadSchema,
 		},
 		{
@@ -105,6 +107,7 @@ func TestValidateAndUpload(t *testing.T) {
 			experiment:      testExperiment,
 			datatype:        testDatatype,
 			dtSchemaFile:    "testdata/datatypes/foo1-invalid.json", // this file doesn't exist
+			uploadSchema:    true,
 			wantErr:         schema.ErrUnmarshal,
 		},
 		{
@@ -115,6 +118,7 @@ func TestValidateAndUpload(t *testing.T) {
 			experiment:      testExperiment,
 			datatype:        testDatatype,
 			dtSchemaFile:    "testdata/datatypes/foo1-valid.json",
+			uploadSchema:    true,
 			wantErr:         schema.ErrStorageClient,
 		},
 		{
@@ -125,6 +129,7 @@ func TestValidateAndUpload(t *testing.T) {
 			experiment:      testExperiment,
 			datatype:        testDatatype,
 			dtSchemaFile:    "testdata/datatypes/foo1-valid.json",
+			uploadSchema:    true,
 			wantErr:         schema.ErrUpload,
 		},
 		{
@@ -135,6 +140,7 @@ func TestValidateAndUpload(t *testing.T) {
 			experiment:      testExperiment,
 			datatype:        testDatatype,
 			dtSchemaFile:    "testdata/datatypes/foo1-valid.json",
+			uploadSchema:    true,
 			wantErr:         nil,
 		},
 		{
@@ -145,6 +151,7 @@ func TestValidateAndUpload(t *testing.T) {
 			experiment:      testExperiment,
 			datatype:        testDatatype,
 			dtSchemaFile:    "testdata/datatypes/foo1-valid.json",
+			uploadSchema:    true,
 			wantErr:         schema.ErrDownload,
 		},
 		{
@@ -155,6 +162,7 @@ func TestValidateAndUpload(t *testing.T) {
 			experiment:      testExperiment,
 			datatype:        testDatatype,
 			dtSchemaFile:    "testdata/datatypes/foo1-valid.json",
+			uploadSchema:    true,
 			wantErr:         nil,
 		},
 		{
@@ -165,6 +173,7 @@ func TestValidateAndUpload(t *testing.T) {
 			experiment:      testExperiment,
 			datatype:        testDatatype,
 			dtSchemaFile:    "testdata/datatypes/foo1-valid-superset.json",
+			uploadSchema:    true,
 			wantErr:         nil,
 		},
 		{
@@ -175,6 +184,7 @@ func TestValidateAndUpload(t *testing.T) {
 			experiment:      testExperiment,
 			datatype:        testDatatype,
 			dtSchemaFile:    "testdata/datatypes/foo1-valid.json",
+			uploadSchema:    true,
 			wantErr:         schema.ErrOnlyInOld,
 		},
 		{
@@ -185,7 +195,19 @@ func TestValidateAndUpload(t *testing.T) {
 			experiment:      testExperiment,
 			datatype:        testDatatype,
 			dtSchemaFile:    "testdata/datatypes/foo1-incompatible.json",
+			uploadSchema:    true,
 			wantErr:         schema.ErrTypeMismatch,
+		},
+		{
+			name:            "scenario 5 no-upload - old exists, new is backward-compatible - should succeed",
+			tblSchemaFile:   "autoload/v1/tables/jostler/foo1.table.json",
+			rmTblSchemaFile: false,
+			bucket:          "newclient,download",
+			experiment:      testExperiment,
+			datatype:        testDatatype,
+			dtSchemaFile:    "testdata/datatypes/foo1-valid.json",
+			uploadSchema:    false,
+			wantErr:         nil,
 		},
 	}
 
@@ -212,7 +234,7 @@ func TestValidateAndUpload(t *testing.T) {
 			}
 			t.Fatalf("testhelper.NewClient() = %v, wanted nil", err)
 		}
-		gotErr := schema.ValidateAndUpload(stClient, test.bucket, test.experiment, test.datatype, test.dtSchemaFile, true)
+		gotErr := schema.ValidateAndUpload(stClient, test.bucket, test.experiment, test.datatype, test.dtSchemaFile, test.uploadSchema)
 		t.Logf("%s>>> gotErr=%v%s\n\n", testhelper.ANSIPurple, gotErr, testhelper.ANSIEnd)
 		if gotErr == nil && test.wantErr == nil {
 			continue

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -155,7 +155,7 @@ func TestValidateAndUpload(t *testing.T) {
 			experiment:      testExperiment,
 			datatype:        testDatatype,
 			dtSchemaFile:    "testdata/datatypes/foo1-valid.json",
-			wantErr:         schema.ErrSchemaMatch,
+			wantErr:         nil,
 		},
 		{
 			name:            "scenario 3 - old exists, new is a superset, should upload",
@@ -212,7 +212,7 @@ func TestValidateAndUpload(t *testing.T) {
 			}
 			t.Fatalf("testhelper.NewClient() = %v, wanted nil", err)
 		}
-		gotErr := schema.ValidateAndUpload(stClient, test.bucket, test.experiment, test.datatype, test.dtSchemaFile)
+		gotErr := schema.ValidateAndUpload(stClient, test.bucket, test.experiment, test.datatype, test.dtSchemaFile, true)
 		t.Logf("%s>>> gotErr=%v%s\n\n", testhelper.ANSIPurple, gotErr, testhelper.ANSIEnd)
 		if gotErr == nil && test.wantErr == nil {
 			continue


### PR DESCRIPTION
This change follows the discussion from https://github.com/m-lab/jostler/pull/51 to simplify the logic used in the schema upload and validate cases needed to support the autoload/v2 conventions.

This change moves the logic from main.go to `schema.ValidateAndUpload` by adding a new parameter for `uploadSchema`. The previously exported function `schema.Validate` is now private to the schema package, and `schema.ValidateAndUpload` checks valid schema conditions depending on whether we wish to upload the local schema or not.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/jostler/52)
<!-- Reviewable:end -->
