### PR TITLE
Fix: set archiver.Version and archiver.GitCommit from git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV CGO_ENABLED 0
 RUN go get -v ./...
 RUN go install -v \
                -ldflags "-X github.com/m-lab/go/prometheusx.GitShortCommit=$(git log -1 --format=%h) \
-               -X main.Version=$VERSION \
+               -X main.Version=$( git describe --exact-match --tags `git log -n1 --pretty='%h'` 2> /dev/null || git rev-parse --abbrev-ref HEAD ) \
                -X main.GitCommit=$(git log -1 --format=%H)" \
       ./cmd/jostler
 

--- a/cmd/jostler/cli.go
+++ b/cmd/jostler/cli.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"log"
 	"regexp"
 	"strings"
 	"time"
@@ -118,6 +119,7 @@ func parseAndValidateCLI() error {
 	// Enable verbose mode in all packages as soon as the flags are
 	// parsed because they may be called for during argument validation.
 	if verbose {
+		log.Println(GitCommit, Version)
 		gcs.Verbose(testhelper.VLogf)
 		schema.Verbose(testhelper.VLogf)
 		watchdir.Verbose(testhelper.VLogf)

--- a/cmd/jostler/cli.go
+++ b/cmd/jostler/cli.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"log"
 	"regexp"
 	"strings"
 	"time"
@@ -119,7 +118,6 @@ func parseAndValidateCLI() error {
 	// Enable verbose mode in all packages as soon as the flags are
 	// parsed because they may be called for during argument validation.
 	if verbose {
-		log.Println(GitCommit, Version)
 		gcs.Verbose(testhelper.VLogf)
 		schema.Verbose(testhelper.VLogf)
 		watchdir.Verbose(testhelper.VLogf)

--- a/cmd/jostler/main.go
+++ b/cmd/jostler/main.go
@@ -23,8 +23,8 @@ import (
 )
 
 var (
-	version   string // set at build time from git describe --tags
-	gitCommit string // set at build time from git log -1 --format=%h
+	Version   string // set at build time from git describe --tags
+	GitCommit string // set at build time from git log -1 --format=%h
 
 	errWrite = errors.New("failed to write file")
 

--- a/cmd/jostler/main.go
+++ b/cmd/jostler/main.go
@@ -197,8 +197,8 @@ func startUploader(mainCtx context.Context, mainCancel context.CancelFunc, statu
 		BaseID:    fmt.Sprintf("%s-%s-%s-%s", datatype, nameParts.Machine, nameParts.Site, experiment),
 	}
 	bundleConf := uploadbundle.BundleConfig{
-		Version:   version,
-		GitCommit: gitCommit,
+		Version:   Version,
+		GitCommit: GitCommit,
 		Datatype:  datatype,
 		SpoolDir:  filepath.Join(localDataDir, experiment, datatype),
 		SizeMax:   bundleSizeMax,


### PR DESCRIPTION
This change modifies the Dockerfile build of the jostler to correctly set the `archiver.Version` and `archiver.GitCommit` at build time.

Previously, we found that all known jostler data is missing the Version and GitCommit values https://github.com/m-lab/jostler/issues/54. This appears to have been caused by:
* A mismatch in the variable case used in main.go (lowercase, e.g. `version`) and the Dockerfile build (`main.Version`).
* The build argument for VERSION not being available during the dockerhub build.

This change uses git commands to automatically discover the version and git commit from the local git metadata at build time.

Fixes https://github.com/m-lab/jostler/issues/54

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/jostler/55)
<!-- Reviewable:end -->
